### PR TITLE
fix: 增加 remax-cli 缺失的 acorn-walk 依赖

### DIFF
--- a/packages/remax-cli/package.json
+++ b/packages/remax-cli/package.json
@@ -26,6 +26,7 @@
     "@babel/types": "^7.4.4",
     "@meck/rollup-plugin-postcss": "^2.0.3",
     "@remax/postcss-px2units": "^0.2.0",
+    "acorn-walk": "^7.0.0",
     "babel-plugin-transform-async-to-promises": "^0.8.14",
     "commander": "^2.19.0",
     "ejs": "^2.6.1",


### PR DESCRIPTION
在 remax-cli 里引入了 acorn-walk 但是没在 package.json 里声明，导致在用  remax-cli 创建启动项目时报错找不到 acorn-walk 的依赖。