### PR TITLE
使编译时的特定环境变量可被访问并使其在解构赋值时工作

### DIFF
--- a/packages/remax-cli/src/build/rollupConfig.ts
+++ b/packages/remax-cli/src/build/rollupConfig.ts
@@ -92,7 +92,7 @@ export default function rollupConfig(
 
   Object.keys(process.env).forEach(k => {
     if (k.startsWith('REMAX_') || k.startsWith('APP_')) {
-      envReplacement[k] = JSON.stringify(process.env[k]);
+      envReplacement[`process.env.${k}`] = JSON.stringify(process.env[k]);
     }
   });
 

--- a/packages/remax-cli/src/build/rollupConfig.ts
+++ b/packages/remax-cli/src/build/rollupConfig.ts
@@ -83,16 +83,14 @@ export default function rollupConfig(
   const cssModuleConfig = getCssModuleConfig(options.cssModules);
 
   const envReplacement: Env = {
-    'process.env.NODE_ENV': JSON.stringify(
-      process.env.NODE_ENV || 'development'
-    ),
-    'process.env.REMAX_PLATFORM': JSON.stringify(argv.target),
-    'process.env.REMAX_DEBUG': JSON.stringify(process.env.REMAX_DEBUG),
+    NODE_ENV: process.env.NODE_ENV || 'development',
+    REMAX_PLATFORM: argv.target,
+    REMAX_DEBUG: process.env.REMAX_DEBUG,
   };
 
   Object.keys(process.env).forEach(k => {
     if (k.startsWith('REMAX_') || k.startsWith('APP_')) {
-      envReplacement[`process.env.${k}`] = JSON.stringify(process.env[k]);
+      envReplacement[`${k}`] = process.env[k];
     }
   });
 
@@ -166,6 +164,11 @@ export default function rollupConfig(
       plugins: [pxToUnits()],
     }),
     json({}),
+    replace({
+      values: {
+        'process.env': JSON.stringify(envReplacement),
+      },
+    }),
     resolve({
       dedupe: [
         'react',
@@ -179,7 +182,6 @@ export default function rollupConfig(
         moduleDirectory: 'node_modules',
       },
     }),
-    replace(envReplacement),
     rename({
       include: 'src/**',
       map: input => {

--- a/packages/remax-cli/src/types.ts
+++ b/packages/remax-cli/src/types.ts
@@ -5,3 +5,6 @@ export interface Context {
   app: any;
   pages: Array<{ path: string; [key: string]: any }>;
 }
+export interface Env {
+  [key: string]: string;
+}

--- a/packages/remax-cli/src/types.ts
+++ b/packages/remax-cli/src/types.ts
@@ -6,5 +6,5 @@ export interface Context {
   pages: Array<{ path: string; [key: string]: any }>;
 }
 export interface Env {
-  [key: string]: string;
+  [key: string]: string | undefined;
 }


### PR DESCRIPTION
使以`APP_`和`REMAX_`开头的名称的环境变量可通过`process.env`被访问。

使用场景参见：[https://create-react-app.dev/docs/adding-custom-environment-variables](https://create-react-app.dev/docs/adding-custom-environment-variables)