### PR TITLE
使编译时的特定环境变量可被访问并使其在解构赋值时工作

### DIFF
--- a/packages/remax-cli/src/build/rollupConfig.ts
+++ b/packages/remax-cli/src/build/rollupConfig.ts
@@ -72,16 +72,14 @@ export default function rollupConfig(
   const cssModuleConfig = getCssModuleConfig(options.cssModules);
 
   const envReplacement: Env = {
-    'process.env.NODE_ENV': JSON.stringify(
-      process.env.NODE_ENV || 'development'
-    ),
-    'process.env.REMAX_PLATFORM': JSON.stringify(argv.target),
-    'process.env.REMAX_DEBUG': JSON.stringify(process.env.REMAX_DEBUG),
+    NODE_ENV: process.env.NODE_ENV || 'development',
+    REMAX_PLATFORM: argv.target,
+    REMAX_DEBUG: process.env.REMAX_DEBUG,
   };
 
   Object.keys(process.env).forEach(k => {
     if (k.startsWith('REMAX_') || k.startsWith('APP_')) {
-      envReplacement[`process.env.${k}`] = JSON.stringify(process.env[k]);
+      envReplacement[`${k}`] = process.env[k];
     }
   });
 
@@ -155,6 +153,11 @@ export default function rollupConfig(
       plugins: [pxToUnits()],
     }),
     json({}),
+    replace({
+      values: {
+        'process.env': JSON.stringify(envReplacement),
+      },
+    }),
     resolve({
       dedupe: [
         'react',
@@ -168,7 +171,6 @@ export default function rollupConfig(
         moduleDirectory: 'node_modules',
       },
     }),
-    replace(envReplacement),
     rename({
       include: 'src/**',
       map: input => {

--- a/packages/remax-cli/src/build/rollupConfig.ts
+++ b/packages/remax-cli/src/build/rollupConfig.ts
@@ -78,7 +78,7 @@ export default function rollupConfig(
   };
 
   Object.keys(process.env).forEach(k => {
-    if (k.startsWith('REMAX_') || k.startsWith('APP_')) {
+    if (k.startsWith('REMAX_APP_')) {
       envReplacement[`${k}`] = process.env[k];
     }
   });

--- a/packages/remax-cli/src/build/rollupConfig.ts
+++ b/packages/remax-cli/src/build/rollupConfig.ts
@@ -27,7 +27,7 @@ import { RemaxOptions } from '../getConfig';
 import app from './plugins/app';
 import removeESModuleFlag from './plugins/removeESModuleFlag';
 import adapters, { Adapter } from './adapters';
-import { Context } from '../types';
+import { Context, Env } from '../types';
 
 export default function rollupConfig(
   options: RemaxOptions,
@@ -70,6 +70,20 @@ export default function rollupConfig(
 
   const entries = getEntries(options, adapter, context);
   const cssModuleConfig = getCssModuleConfig(options.cssModules);
+
+  const envReplacement: Env = {
+    'process.env.NODE_ENV': JSON.stringify(
+      process.env.NODE_ENV || 'development'
+    ),
+    'process.env.REMAX_PLATFORM': JSON.stringify(argv.target),
+    'process.env.REMAX_DEBUG': JSON.stringify(process.env.REMAX_DEBUG),
+  };
+
+  Object.keys(process.env).forEach(k => {
+    if (k.startsWith('REMAX_') || k.startsWith('APP_')) {
+      envReplacement[k] = JSON.stringify(process.env[k]);
+    }
+  });
 
   const plugins = [
     clean({
@@ -154,13 +168,7 @@ export default function rollupConfig(
         moduleDirectory: 'node_modules',
       },
     }),
-    replace({
-      'process.env.NODE_ENV': JSON.stringify(
-        process.env.NODE_ENV || 'development'
-      ),
-      'process.env.REMAX_PLATFORM': JSON.stringify(argv.target),
-      'process.env.REMAX_DEBUG': JSON.stringify(process.env.REMAX_DEBUG),
-    }),
+    replace(envReplacement),
     rename({
       include: 'src/**',
       map: input => {

--- a/packages/remax-cli/src/build/rollupConfig.ts
+++ b/packages/remax-cli/src/build/rollupConfig.ts
@@ -81,7 +81,7 @@ export default function rollupConfig(
 
   Object.keys(process.env).forEach(k => {
     if (k.startsWith('REMAX_') || k.startsWith('APP_')) {
-      envReplacement[k] = JSON.stringify(process.env[k]);
+      envReplacement[`process.env.${k}`] = JSON.stringify(process.env[k]);
     }
   });
 

--- a/packages/remax-cli/src/types.ts
+++ b/packages/remax-cli/src/types.ts
@@ -5,3 +5,6 @@ export interface Context {
   app: any;
   pages: Array<{ path: string; [key: string]: any }>;
 }
+export interface Env {
+  [key: string]: string;
+}

--- a/packages/remax-cli/src/types.ts
+++ b/packages/remax-cli/src/types.ts
@@ -6,5 +6,5 @@ export interface Context {
   pages: Array<{ path: string; [key: string]: any }>;
 }
 export interface Env {
-  [key: string]: string;
+  [key: string]: string | undefined;
 }


### PR DESCRIPTION
使以`APP_`和`REMAX_`开头的名称的环境变量可通过`process.env`被访问。

使用场景参见：[https://create-react-app.dev/docs/adding-custom-environment-variables](https://create-react-app.dev/docs/adding-custom-environment-variables)