### PR TITLE
Build/copy

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -18,6 +18,8 @@ module.exports = {
   progress: true,
   // build 目录，默认 dist
   output: 'dist',
+  // copy 文件配置
+  copy: [],
 };
 ```
 
@@ -32,6 +34,21 @@ import Button from '@/components/Button';
 
 // 相当于
 import Button from 'project_cwd/src/components/Button';
+```
+
+### 文件 copy 配置
+
+Remax 支持拷贝文件或者目录，**数组类型**，每一项都必须包含 src 、dest 的配置，分别代表来源和需要拷贝到的目录，支持 glob 模式。
+
+```js
+module.exports = {
+  copy: [
+    {
+      src: 'path/to/your/directory',
+      dest: 'dist',
+    },
+  ],
+};
 ```
 
 ### 文件引用

--- a/packages/remax-cli/src/build/rollupConfig.ts
+++ b/packages/remax-cli/src/build/rollupConfig.ts
@@ -71,9 +71,10 @@ export default function rollupConfig(
     copy({
       targets: [
         {
-          src: ['src/native/*'],
-          dest: 'dist',
+          src: ['src/native/*', 'project.config.json'],
+          dest: options.output,
         },
+        ...options.copy!,
       ],
       copyOnce: true,
     }),

--- a/packages/remax-cli/src/defaultOptions.ts
+++ b/packages/remax-cli/src/defaultOptions.ts
@@ -6,6 +6,7 @@ const defaultOptions: RemaxOptions = {
   progress: true,
   output: 'dist',
   UNSAFE_wechatTemplateDepth: 20,
+  copy: [],
 };
 
 export default defaultOptions;

--- a/packages/remax-cli/src/getConfig.ts
+++ b/packages/remax-cli/src/getConfig.ts
@@ -2,6 +2,11 @@ import fs from 'fs';
 import path from 'path';
 import defaultOptions from './defaultOptions';
 
+interface CopyOptions {
+  src: string | Array<string>;
+  dest: string | Array<string>;
+}
+
 export interface RemaxOptions {
   cssModules: boolean | RegExp;
   cwd: string;
@@ -9,6 +14,7 @@ export interface RemaxOptions {
   output: string;
   UNSAFE_wechatTemplateDepth: number;
   alias?: any;
+  copy?: Array<CopyOptions>;
 }
 
 export interface CliOptions {


### PR DESCRIPTION
需要在 remax.config.js 里 增加一个 copy option，类似于 taro 的配置一样https://taro-docs.jd.com/taro/docs/config-detail.html#copyoptions，这样不仅仅头条的 project.config.json 能够被复制过去，其他的文件也可以复制过去。