### PR TITLE
修改 css modules 的使用方式

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -10,8 +10,8 @@ order: 22
 ```js
 // remax.config.js 默认配置
 module.exports = {
-  // boolean | RegExp 开启或关闭 css modules，支持传入正则表达式配置开启的文件命名格式
-  cssModules: /\.module\.(less|scss|css)$/,
+  // 为 true 则开启 css modules
+  cssModules: false,
   // 配置项目路径，默认当前路径
   cwd: process.cwd(),
   // 是否显示 build 进度，默认显示

--- a/docs/guide/style.md
+++ b/docs/guide/style.md
@@ -32,18 +32,16 @@ Remax 会自动把 `px` 转换成小程序 `rpx`：
 
 如果你不想转换 `px` ，就写成 `PX`，如：
 
-```
+```css
 .view {
   height: 16PX:
 }
 ```
 
-Remax 同时也支持 [Css Modules](https://github.com/css-modules/css-modules)
-
-所有以 `module.css|less` 结尾的文件都将按照 **Css Modules** 处理。如：
+Remax 同时也支持 [Css Modules](https://github.com/css-modules/css-modules)，只需在 `remax.config.js` 设置 `cssModules` 为 `true`:
 
 ```css
-/* index.module.css */
+/* index.css */
 
 .view {
   display: flex;
@@ -51,14 +49,12 @@ Remax 同时也支持 [Css Modules](https://github.com/css-modules/css-modules)
 ```
 
 ```js
-import styles from './index.module.css';
+import './index.css';
 
 export default function() {
-  return <View className={styles.view}> view </View>;
+  return <View styleName="view"> view </View>;
 }
 ```
-
-你也可以通过 `remax.config.js` 配置不同的 Css Modules 匹配规则，关于 Remax 配置请参考 [指南 - 配置](/guide/config)
 
 ## 小程序自定义组件样式
 

--- a/packages/remax-cli/package.json
+++ b/packages/remax-cli/package.json
@@ -41,11 +41,14 @@
     "@remax/postcss-px2units": "^0.2.0",
     "@remax/regenerator-runtime": "^0.11.1",
     "acorn-walk": "^7.0.0",
+    "babel-plugin-react-css-modules": "^5.2.6",
     "chokidar": "^2.1.8",
     "commander": "^2.19.0",
     "ejs": "^2.6.1",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",
+    "postcss-less": "^3.1.4",
+    "postcss-scss": "^2.0.0",
     "postcss-url": "^8.0.0",
     "rollup": "^1.16.0",
     "rollup-plugin-alias": "^1.5.2",
@@ -62,6 +65,7 @@
     "rollup-plugin-url": "^2.2.2",
     "scheduler": "0.13.6",
     "slash2": "^2.0.0",
+    "sugarss": "^2.0.0",
     "yargs": "^13.2.4"
   },
   "devDependencies": {

--- a/packages/remax-cli/src/build/adapters/alipay/index.ts
+++ b/packages/remax-cli/src/build/adapters/alipay/index.ts
@@ -27,6 +27,7 @@ export const moduleFormat = 'esm';
 const alias: any = {
   className: 'class',
   onClick: 'onTap',
+  styleName: 'class',
 };
 
 export function getNativePropName(prop: string) {

--- a/packages/remax-cli/src/build/adapters/wechat/index.ts
+++ b/packages/remax-cli/src/build/adapters/wechat/index.ts
@@ -29,6 +29,7 @@ const alias: { [prop: string]: string } = {
   activeColor: 'activeColor',
   backgroundColor: 'backgroundColor',
   onClick: 'bindtap',
+  styleName: 'class',
 };
 
 export function getNativePropName(prop: string) {

--- a/packages/remax-cli/src/defaultOptions.ts
+++ b/packages/remax-cli/src/defaultOptions.ts
@@ -1,7 +1,7 @@
 import { RemaxOptions } from './getConfig';
 
 const defaultOptions: RemaxOptions = {
-  cssModules: /\.module\.(less|scss|css)$/,
+  cssModules: false,
   cwd: process.cwd(),
   progress: true,
   output: 'dist',

--- a/packages/remax-cli/src/getConfig.ts
+++ b/packages/remax-cli/src/getConfig.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import defaultOptions from './defaultOptions';
 
 export interface RemaxOptions {
-  cssModules: boolean | RegExp;
+  cssModules: boolean;
   cwd: string;
   progress: boolean;
   output: string;

--- a/packages/remax-cli/src/getCssModuleConfig.ts
+++ b/packages/remax-cli/src/getCssModuleConfig.ts
@@ -1,15 +1,7 @@
-function getCssModuleConfig(cssModule: boolean | RegExp) {
-  let regStr = cssModule.toString();
-
-  if (typeof cssModule === 'boolean') {
-    regStr = cssModule ? '^(?!.*.*)' : '(.*)';
-  } else {
-    regStr = '^(?!.*' + cssModule.toString().replace(/^\/|\/$/g, '') + ')';
-  }
-
+export default function getCssModuleConfig(cssModule: boolean) {
   return {
-    globalModulePaths: [new RegExp(regStr)],
+    cssModule,
+    globalModulePaths: [cssModule ? /^(?!.*.*)/ : /.*/],
+    generateScopedName: '[name]_[local]__[hash:base64:5]',
   };
 }
-
-export default getCssModuleConfig;


### PR DESCRIPTION
目前使用 css modules 的时候有些麻烦，需要先引入 styles， 然后在 className 上使用，现在则是引入了 `babel-plugin-react-css-modules`，使用 css modules 更加方便