### PR TITLE
fix: 修复较为动态地使用 Remax 组件时可能不会渲染的问题

### DIFF
--- a/packages/remax-cli/src/__tests__/index.test.ts
+++ b/packages/remax-cli/src/__tests__/index.test.ts
@@ -20,7 +20,7 @@ async function build(app: string) {
     .filter(c => !/(node_modules|_virtual)/.test(c.fileName))
     .map(c => {
       let code = '';
-      if (c.code) {
+      if (c.type === 'chunk' && c.code) {
         code = c.code.toString();
       } else {
         code = (c as rollup.OutputAsset).source.toString();

--- a/packages/remax-cli/src/build/plugins/components.ts
+++ b/packages/remax-cli/src/build/plugins/components.ts
@@ -5,19 +5,39 @@ import { kebabCase } from 'lodash';
 import { Adapter } from '../adapters';
 
 interface Component {
-  type: string;
   id: string;
   props: string[];
-  children?: Component[];
 }
 
-const components: { [id: string]: Component } = {};
+interface ComponentCollection {
+  [id: string]: Component;
+}
 
-function shouldRegisterAllProps(
-  adapter: Adapter,
-  node: t.JSXElement,
-  componentName: string
+const components: ComponentCollection = {};
+const importedComponents: ComponentCollection = {};
+
+function addToComponentCollection(
+  component: Component,
+  componentCollection: ComponentCollection
 ) {
+  if (!componentCollection[component.id]) {
+    componentCollection[component.id] = component;
+  }
+
+  component.props.forEach(prop => {
+    if (
+      componentCollection[component.id].props.findIndex(
+        item => item === prop
+      ) !== -1
+    ) {
+      return;
+    }
+
+    componentCollection[component.id].props.push(prop);
+  });
+}
+
+function shouldRegisterAllProps(adapter: Adapter, node: t.JSXElement) {
   if (adapter.name === 'alipay') {
     return true;
   }
@@ -31,8 +51,63 @@ function shouldRegisterAllProps(
   return false;
 }
 
+function registerComponent(
+  componentName: string,
+  componentCollection: ComponentCollection,
+  adapter: Adapter,
+  node?: t.JSXElement
+) {
+  if (componentName === 'swiper-item') {
+    return;
+  }
+
+  if (adapter.name === 'alipay' && componentName === 'picker-view-column') {
+    return;
+  }
+
+  try {
+    if (!adapter.hostComponents(componentName)) {
+      return;
+    }
+  } catch (error) {
+    return;
+  }
+
+  let usedProps = adapter.hostComponents(componentName).props;
+  if (node && !shouldRegisterAllProps(adapter, node)) {
+    usedProps = node.openingElement.attributes.map(e => {
+      const propName = get(e, 'name.name') as string;
+      return propName;
+    });
+  }
+
+  const props = usedProps.filter(prop => !!prop).map(adapter.getNativePropName);
+
+  const component = {
+    id: componentName,
+    props,
+  };
+
+  addToComponentCollection(component, componentCollection);
+}
+
 export default (adapter: Adapter) => () => ({
   visitor: {
+    ImportDeclaration(path: NodePath) {
+      const node = path.node as t.ImportDeclaration;
+
+      if (!node.source.value.startsWith('remax/')) {
+        return;
+      }
+
+      node.specifiers.forEach(specifier => {
+        if (t.isImportSpecifier(specifier)) {
+          const componentName = specifier.imported.name;
+          const id = kebabCase(componentName);
+          registerComponent(id, importedComponents, adapter);
+        }
+      });
+    },
     JSXElement(path: NodePath) {
       const node = path.node as t.JSXElement;
       if (t.isJSXIdentifier(node.openingElement.name)) {
@@ -54,47 +129,20 @@ export default (adapter: Adapter) => () => ({
         const componentName = componentPath.node.imported.name;
         const id = kebabCase(componentName);
 
-        if (id === 'swiper-item') {
-          return;
-        }
-
-        if (adapter.name === 'alipay' && id === 'picker-view-column') {
-          return;
-        }
-
-        let usedProps = adapter.hostComponents(id).props;
-
-        if (!shouldRegisterAllProps(adapter, node, componentName)) {
-          usedProps = node.openingElement.attributes.map(e => {
-            const propName = get(e, 'name.name') as string;
-            return propName;
-          });
-        }
-
-        const props = usedProps
-          .filter(prop => !!prop)
-          .map(prop => adapter.getNativePropName(prop as string));
-
-        if (!components[id]) {
-          components[id] = {
-            type: kebabCase(componentName),
-            id,
-            props,
-          };
-        }
-
-        props.forEach(prop => {
-          if (components[id].props.findIndex(item => item === prop) !== -1) {
-            return;
-          }
-
-          components[id].props.push(prop);
-        });
+        registerComponent(id, components, adapter, node);
       }
     },
   },
 });
 
 export function getComponents() {
-  return Object.values(components);
+  const data = Object.values(components);
+
+  Object.values(importedComponents).forEach(c => {
+    if (!components[c.id]) {
+      data.push(c);
+    }
+  });
+
+  return data;
 }

--- a/packages/remax-cli/src/build/plugins/components.ts
+++ b/packages/remax-cli/src/build/plugins/components.ts
@@ -1,4 +1,7 @@
 import * as t from '@babel/types';
+import * as PATH from 'path';
+import winPath from '../../winPath';
+import fs from 'fs';
 import { NodePath } from '@babel/traverse';
 import { get } from 'dot-prop';
 import { kebabCase } from 'lodash';
@@ -135,7 +138,24 @@ export default (adapter: Adapter) => () => ({
   },
 });
 
-export function getComponents() {
+function getAlipayComponents(adapter: Adapter) {
+  const DIR_PATH = winPath(
+    PATH.resolve(__dirname, '../adapters/alipay/hostComponents')
+  );
+  const files = fs.readdirSync(DIR_PATH);
+  files.forEach(file => {
+    const name = PATH.basename(file).replace(PATH.extname(file), '');
+    registerComponent(name, components, adapter);
+  });
+
+  return Object.values(components);
+}
+
+export function getComponents(adapter: Adapter) {
+  if (adapter.name === 'alipay') {
+    return getAlipayComponents(adapter);
+  }
+
   const data = Object.values(components);
 
   Object.values(importedComponents).forEach(c => {

--- a/packages/remax-cli/src/build/plugins/template.ts
+++ b/packages/remax-cli/src/build/plugins/template.ts
@@ -33,6 +33,7 @@ async function createTemplate(pageFile: string, adapter: Adapter) {
 
   return {
     fileName,
+    type: 'asset' as 'asset',
     isAsset: true as true,
     source: code,
   };
@@ -45,13 +46,14 @@ async function createHelperFile(adapter: Adapter) {
 
   return {
     fileName: `helper${adapter.extensions.jsHelper}`,
+    type: 'asset' as 'asset',
     isAsset: true as true,
     source: code,
   };
 }
 
 async function createBaseTemplate(adapter: Adapter, options: RemaxOptions) {
-  const components = getComponents();
+  const components = getComponents(adapter);
   let code: string = await ejs.renderFile(
     adapter.templates.base,
     {
@@ -71,6 +73,7 @@ async function createBaseTemplate(adapter: Adapter, options: RemaxOptions) {
 
   return {
     fileName: `base${adapter.extensions.template}`,
+    type: 'asset' as 'asset',
     isAsset: true as true,
     source: code,
   };
@@ -86,6 +89,7 @@ function createAppManifest(
     : readManifest(path.resolve(options.cwd, 'src/app.config.js'), target);
   return {
     fileName: 'app.json',
+    type: 'asset' as 'asset',
     isAsset: true as true,
     source: JSON.stringify(config, null, 2),
   };
@@ -108,6 +112,7 @@ function createPageManifest(
     return {
       fileName: manifestFile,
       isAsset: true as true,
+      type: 'asset' as 'asset',
       source: JSON.stringify(readManifest(configFilePath, target), null, 2),
     };
   }
@@ -119,6 +124,7 @@ function createPageManifest(
       return {
         fileName: manifestFile,
         isAsset: true as true,
+        type: 'asset' as 'asset',
         source: JSON.stringify(config, null, 2),
       };
     }

--- a/packages/remax-cli/templates/alipay/base.ejs
+++ b/packages/remax-cli/templates/alipay/base.ejs
@@ -6,7 +6,6 @@
 
 <% for (let component of components) { %>
 <%- include('./component.ejs', {
-        type: component.type,
         props: component.props,
         id: component.id,
       }) %>

--- a/packages/remax-cli/templates/wechat/base.ejs
+++ b/packages/remax-cli/templates/wechat/base.ejs
@@ -16,7 +16,6 @@
 <%var id = i; %>
 <% for (let component of components) { %>
 <%- include('./component.ejs', {
-        type: component.type,
         props: component.props,
         id: component.id,
         templateId: id,


### PR DESCRIPTION
目前微信必须显式得在 jsx 中调用 remax 组件，才会收集到 remax 组件信息。现在修改成从 import 语句收集组件信息，就可以使微信支持更动态的写法