### PR TITLE
fix: 图片资源编译以后目录和 src 下不一致

### DIFF
--- a/packages/remax-cli/src/build/rollupConfig.ts
+++ b/packages/remax-cli/src/build/rollupConfig.ts
@@ -95,6 +95,7 @@ export default function rollupConfig(
       limit: 0,
       fileName: '[dirname][name][extname]',
       publicPath: '/',
+      sourceDir: path.resolve(options.cwd, 'src'),
       include: ['**/*.svg', '**/*.png', '**/*.jpg', '**/*.jpeg', '**/*.gif'],
     }),
     commonjs({


### PR DESCRIPTION
https://github.com/remaxjs/remax/issues/224