### PR TITLE
feat: 添加postcss 配置项

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -20,6 +20,27 @@ module.exports = {
   output: 'dist',
   // 配置路径别名
   alias: {},
+  postcss: {
+    options: {
+      use: [
+        [
+          'less',
+          {
+            paths: [
+              // 可方便解析 node_modules 中样式文件
+              path.resolve(__dirname, 'node_modules'),
+              // 可作为全局样式目录
+              path.resolve(__dirname, 'src/assets/styles'),
+            ],
+          },
+        ],
+        // 其他样式文件配置，比如sass, stylus, 如果有多种样式文件，则也需要添加对应配置
+        ['stylus', {}],
+      ],
+    },
+    // 其他postcss 插件, 会和默认的插件进行拼接
+    plugins: [],
+  },
 };
 ```
 

--- a/packages/remax-cli/src/build/rollupConfig.ts
+++ b/packages/remax-cli/src/build/rollupConfig.ts
@@ -76,6 +76,13 @@ export default function rollupConfig(
     {} as any
   );
 
+  // 获取 postcss 配置
+  const postcssConfig = {
+    options: {},
+    plugins: [],
+    ...options.postcss,
+  };
+
   const envReplacement: Env = {
     NODE_ENV: process.env.NODE_ENV || 'development',
     REMAX_PLATFORM: argv.target,
@@ -149,8 +156,9 @@ export default function rollupConfig(
     }),
     postcss({
       extract: true,
+      ...postcssConfig.options,
       modules: cssModuleConfig,
-      plugins: [pxToUnits(), postcssUrl(options)],
+      plugins: [pxToUnits(), postcssUrl(options)].concat(postcssConfig.plugins),
     }),
     json({}),
     replace({

--- a/packages/remax-cli/src/getConfig.ts
+++ b/packages/remax-cli/src/getConfig.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import defaultOptions from './defaultOptions';
+import { PluginImpl } from 'rollup';
 
 export interface RemaxOptions {
   cssModules: boolean | RegExp;
@@ -10,6 +11,12 @@ export interface RemaxOptions {
   UNSAFE_wechatTemplateDepth: number;
   alias?: {
     [key: string]: string;
+  };
+  postcss?: {
+    options?: {
+      [key: string]: any;
+    };
+    plugins?: PluginImpl[];
   };
 }
 


### PR DESCRIPTION
添加 postcss 配置项，用于添加 less/stylus/sass  的配置 等

```
# remax.config.js

{
    postcss: {
        use: [
            ['less', { 
                paths: [path.resolve(__dirname, 'src/asset/style')] 
            }]
        ]
    }
}
```