### PR TITLE
fix: 修复 rebuild 读取到错误的 remax config 文件的问题

### DIFF
--- a/packages/remax-cli/src/getConfig.ts
+++ b/packages/remax-cli/src/getConfig.ts
@@ -28,6 +28,7 @@ export interface CliOptions {
 export default function getConfig(): RemaxOptions {
   const configPath: string = path.join(process.cwd(), './remax.config.js');
   if (fs.existsSync(configPath)) {
+    delete require.cache[require.resolve(configPath)];
     // eslint-disable-next-line
     const options = require(configPath);
 


### PR DESCRIPTION
fix #263