### PR TITLE
fix: 修复钉钉小程序使用原生组件渲染错乱的问题

### DIFF
--- a/packages/remax-cli/src/__tests__/fixtures/alipay/expected/helper.sjs
+++ b/packages/remax-cli/src/__tests__/fixtures/alipay/expected/helper.sjs
@@ -2,9 +2,16 @@ var tree = {
   root: {
     children: [],
   },
+  lastActionId: -1
 };
 
 function reduce(action) {
+  if (action.id === tree.lastActionId) {
+    return tree;
+  }
+
+  tree.lastActionId = action.id;
+
   switch (action.type) {
     case 'clear': 
       tree.root = {

--- a/packages/remax-cli/src/__tests__/fixtures/assets/expected/helper.sjs
+++ b/packages/remax-cli/src/__tests__/fixtures/assets/expected/helper.sjs
@@ -2,9 +2,16 @@ var tree = {
   root: {
     children: [],
   },
+  lastActionId: -1
 };
 
 function reduce(action) {
+  if (action.id === tree.lastActionId) {
+    return tree;
+  }
+
+  tree.lastActionId = action.id;
+
   switch (action.type) {
     case 'clear': 
       tree.root = {

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/helper.sjs
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/helper.sjs
@@ -2,9 +2,16 @@ var tree = {
   root: {
     children: [],
   },
+  lastActionId: -1
 };
 
 function reduce(action) {
+  if (action.id === tree.lastActionId) {
+    return tree;
+  }
+
+  tree.lastActionId = action.id;
+
   switch (action.type) {
     case 'clear': 
       tree.root = {

--- a/packages/remax-cli/src/__tests__/fixtures/customRootDir/expected/helper.sjs
+++ b/packages/remax-cli/src/__tests__/fixtures/customRootDir/expected/helper.sjs
@@ -2,9 +2,16 @@ var tree = {
   root: {
     children: [],
   },
+  lastActionId: -1
 };
 
 function reduce(action) {
+  if (action.id === tree.lastActionId) {
+    return tree;
+  }
+
+  tree.lastActionId = action.id;
+
   switch (action.type) {
     case 'clear': 
       tree.root = {

--- a/packages/remax-cli/src/__tests__/fixtures/nativeComponent/expected/helper.sjs
+++ b/packages/remax-cli/src/__tests__/fixtures/nativeComponent/expected/helper.sjs
@@ -2,9 +2,16 @@ var tree = {
   root: {
     children: [],
   },
+  lastActionId: -1
 };
 
 function reduce(action) {
+  if (action.id === tree.lastActionId) {
+    return tree;
+  }
+
+  tree.lastActionId = action.id;
+
   switch (action.type) {
     case 'clear': 
       tree.root = {

--- a/packages/remax-cli/src/__tests__/fixtures/universe/expected/alipay/helper.sjs
+++ b/packages/remax-cli/src/__tests__/fixtures/universe/expected/alipay/helper.sjs
@@ -2,9 +2,16 @@ var tree = {
   root: {
     children: [],
   },
+  lastActionId: -1
 };
 
 function reduce(action) {
+  if (action.id === tree.lastActionId) {
+    return tree;
+  }
+
+  tree.lastActionId = action.id;
+
   switch (action.type) {
     case 'clear': 
       tree.root = {

--- a/packages/remax-cli/src/__tests__/fixtures/universe/expected/wechat/helper.wxs
+++ b/packages/remax-cli/src/__tests__/fixtures/universe/expected/wechat/helper.wxs
@@ -2,9 +2,16 @@ var tree = {
   root: {
     children: [],
   },
+  lastActionId: -1
 };
 
 function reduce(action) {
+  if (action.id === tree.lastActionId) {
+    return tree;
+  }
+
+  tree.lastActionId = action.id;
+
   switch (action.type) {
     case 'clear': 
       tree.root = {

--- a/packages/remax-cli/src/__tests__/fixtures/wechat/expected/helper.wxs
+++ b/packages/remax-cli/src/__tests__/fixtures/wechat/expected/helper.wxs
@@ -2,9 +2,16 @@ var tree = {
   root: {
     children: [],
   },
+  lastActionId: -1
 };
 
 function reduce(action) {
+  if (action.id === tree.lastActionId) {
+    return tree;
+  }
+
+  tree.lastActionId = action.id;
+
   switch (action.type) {
     case 'clear': 
       tree.root = {

--- a/packages/remax-cli/templates/helper.js
+++ b/packages/remax-cli/templates/helper.js
@@ -2,9 +2,16 @@ var tree = {
   root: {
     children: [],
   },
+  lastActionId: -1
 };
 
 function reduce(action) {
+  if (action.id === tree.lastActionId) {
+    return tree;
+  }
+
+  tree.lastActionId = action.id;
+
   switch (action.type) {
     case 'clear': 
       tree.root = {

--- a/packages/remax/src/Container.ts
+++ b/packages/remax/src/Container.ts
@@ -1,5 +1,6 @@
 import VNode, { Path, RawNode } from './VNode';
 import { generate } from './instanceId';
+import { generate as generateActionId } from './actionId';
 import { FiberRoot } from 'react-reconciler';
 import Platform from './Platform';
 import propsAlias from './propsAlias';
@@ -82,6 +83,7 @@ export default class Container {
         deleteCount: update.deleteCount,
         item: update.items[0],
       })),
+      id: generateActionId(),
     };
 
     let tree: typeof action | { root: RawNode } = action;

--- a/packages/remax/src/__tests__/alipay/index.test.tsx
+++ b/packages/remax/src/__tests__/alipay/index.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import './helpers/setupGlobals';
 import { render, View } from '../../../src/adapters/alipay';
-import { reset } from '../../instanceId';
+import { reset as resetInstanceId } from '../../instanceId';
+import { reset as resetActionId } from '../../actionId';
 import Container from '../../Container';
 
 const p = {
@@ -13,7 +14,8 @@ const p = {
 
 describe('remax render', () => {
   afterEach(() => {
-    reset();
+    resetActionId();
+    resetInstanceId();
   });
 
   it('render correctly', () => {

--- a/packages/remax/src/actionId.ts
+++ b/packages/remax/src/actionId.ts
@@ -1,0 +1,11 @@
+let actionId = 0;
+
+export function reset() {
+  actionId = 0;
+}
+
+export function generate() {
+  const id = actionId;
+  actionId += 1;
+  return id;
+}


### PR DESCRIPTION
实际上是钉钉小程序本身的bug，我们通过废弃已处理过的action来避免这个问题

fix #316