### PR TITLE
feat: babel-preset-remax 增加 decorators 和 class-properties 配置项

### DIFF
--- a/packages/babel-preset-remax/README.md
+++ b/packages/babel-preset-remax/README.md
@@ -8,9 +8,17 @@ Babel preset for remax app.
 
 ## Options
 
-### Typescript
+### typescript
 
 configure typescript preset. https://babeljs.io/docs/en/babel-preset-typescript
+
+### decorators
+
+configure babel proposal decorators. https://babeljs.io/docs/en/babel-plugin-proposal-decorators
+
+### class-properties
+
+configure babel proposal class properties. https://babeljs.io/docs/en/babel-plugin-proposal-class-properties
 
 ```js
 {
@@ -20,6 +28,12 @@ configure typescript preset. https://babeljs.io/docs/en/babel-preset-typescript
       {
         typescript: {
           allowNamespaces: true,
+        },
+        'class-properties': {
+          loose: true,
+        },
+        decorators: {
+          legacy: true,
         },
       },
     ],

--- a/packages/babel-preset-remax/src/index.ts
+++ b/packages/babel-preset-remax/src/index.ts
@@ -3,6 +3,8 @@ import { declare } from '@babel/helper-plugin-utils';
 interface PresetOption {
   react?: boolean;
   typescript?: any;
+  decorators?: any;
+  'class-properties'?: any;
 }
 
 function preset(api: any, presetOption: PresetOption) {
@@ -14,6 +16,10 @@ function preset(api: any, presetOption: PresetOption) {
     typeof presetOption.typescript === 'undefined'
       ? true
       : presetOption.typescript;
+  const classProperties = presetOption['class-properties'] || {};
+  const decorators = presetOption.decorators || {
+    decoratorsBeforeExport: true,
+  };
 
   const presets = [require('@babel/preset-env')];
 
@@ -32,15 +38,10 @@ function preset(api: any, presetOption: PresetOption) {
     presets,
     plugins: [
       require('@remax/babel-plugin-macros'),
-      require('@babel/plugin-proposal-class-properties'),
       require('@babel/plugin-proposal-object-rest-spread'),
       require('@babel/plugin-syntax-jsx'),
-      [
-        require('@babel/plugin-proposal-decorators'),
-        {
-          decoratorsBeforeExport: true,
-        },
-      ],
+      [require('@babel/plugin-proposal-decorators'), decorators],
+      [require('@babel/plugin-proposal-class-properties'), classProperties],
     ],
   };
 }

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/babel.config.js
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/babel.config.js
@@ -10,6 +10,12 @@ module.exports = function(api) {
           typescript: {
             allowNamespaces: true,
           },
+          'class-properties': {
+            loose: true,
+          },
+          decorators: {
+            legacy: true,
+          },
         },
       ],
     ],

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/components/a/index.axml
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/components/a/index.axml
@@ -1,0 +1,1 @@
+<view>a</view>

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/components/a/index.js
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/components/a/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+Component({});

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/components/a/index.json
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/components/a/index.json
@@ -1,0 +1,3 @@
+{
+  "component": true
+}

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/pages/index.axml
@@ -8,6 +8,48 @@
 </template>
 
 
+  <template name="REMAX_TPL_1_a-0">
+  <a-0 ref="{{item.props['__ref']}}">
+    
+    <block a:for="{{item.children}}" key="{{item.id}}">
+      <block a:if="{{item.props['slot']}}">
+        <view  slot="{{item.props['slot']}}"
+           disable-scroll="{{item.props['disable-scroll']}}"
+           hover-class="{{item.props['hover-class']}}"
+           hover-start-time="{{item.props['hover-start-time']}}"
+           hover-stay-time="{{item.props['hover-stay-time']}}"
+           hidden="{{item.props['hidden']}}"
+           class="{{item.props['class']}}"
+           style="{{item.props['style']}}"
+           animation="{{item.props['animation']}}"
+           hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
+           onTap="{{item.props['onTap']}}"
+           onTouchStart="{{item.props['onTouchStart']}}"
+           onTouchMove="{{item.props['onTouchMove']}}"
+           onTouchEnd="{{item.props['onTouchEnd']}}"
+           onTouchCancel="{{item.props['onTouchCancel']}}"
+           onLongTap="{{item.props['onLongTap']}}"
+           onTransitionEnd="{{item.props['onTransitionEnd']}}"
+           onAnimationIteration="{{item.props['onAnimationIteration']}}"
+           onAnimationStart="{{item.props['onAnimationStart']}}"
+           onAnimationEnd="{{item.props['onAnimationEnd']}}"
+           onAppear="{{item.props['onAppear']}}"
+           onDisappear="{{item.props['onDisappear']}}"
+           onFirstAppear="{{item.props['onFirstAppear']}}"
+          >
+          <block a:for="{{item.children}}" key="{{item.id}}">
+            <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
+          </block>
+        </view>
+      </block>
+      <block a:else>
+        <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
+      </block>
+    </block>
+    
+  </a-0>
+</template>
+  
   <template name="REMAX_TPL_1_button">
   <button  app-parameter="{{item.props['app-parameter']}}"  class="{{item.props['class']}}"  data-rid="{{item.props['data-rid']}}"  disabled="{{item.props['disabled']}}"  form-type="{{item.props['form-type']}}"  hover-class="{{item.props['hover-class']}}"  hover-start-time="{{item.props['hover-start-time']}}"  hover-stay-time="{{item.props['hover-stay-time']}}"  hover-stop-propagation="{{item.props['hover-stop-propagation']}}"  loading="{{item.props['loading']}}"  onTap="{{item.props['onTap']}}"  open-type="{{item.props['open-type']}}"  plain="{{item.props['plain']}}"  public-id="{{item.props['public-id']}}"  scope="{{item.props['scope']}}"  size="{{item.props['size']}}"  type="{{item.props['type']}}" >
     

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/pages/index.js
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/pages/index.js
@@ -2,6 +2,7 @@
 
 Object.defineProperty(exports, '__esModule', { value: true });
 
+var _rollupPluginBabelHelpers = require('../_virtual/_rollupPluginBabelHelpers.js');
 require('../npm/remax/esm/render.js');
 var React = require('react');
 require('../npm/remax/esm/createAppConfig.js');
@@ -45,6 +46,8 @@ require('../npm/remax/esm/adapters/alipay/components/ContactButton.js');
 require('../npm/remax/esm/adapters/alipay/components/Video.js');
 require('../npm/remax/esm/adapters/alipay/api.js');
 
+var _class, _descriptor, _temp;
+
 var N;
 
 (function (_N) {
@@ -72,8 +75,28 @@ function timesTwo(arr) {
   return _r;
 }
 
+function readonly(target, name, descriptor) {
+  descriptor.writable = false;
+  return descriptor;
+}
+
+var C = (_class = (_temp = function C() {
+  _rollupPluginBabelHelpers.classCallCheck(this, C);
+
+  _rollupPluginBabelHelpers.initializerDefineProperty(this, "p", _descriptor, this);
+}, _temp), _descriptor = _rollupPluginBabelHelpers.applyDecoratedDescriptor(_class.prototype, "p", [readonly], {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  initializer: function initializer() {
+    return 'p';
+  }
+}), _class);
+var c = new C();
+c.p = 'a';
+
 var _page = function _page() {
-  return React.createElement(View.default, null, timesTwo([1, 2, 3]), N.V, N.W);
+  return React.createElement(View.default, null, timesTwo([1, 2, 3]), N.V, N.W, c.p);
 };
 
 var index = Page(createPageConfig.default(_page));

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/pages/index.js
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/pages/index.js
@@ -9,6 +9,7 @@ require('../npm/remax/esm/createAppConfig.js');
 require('../npm/remax/esm/Platform.js');
 require('../npm/remax/esm/createHostComponent.js');
 var createPageConfig = require('../npm/remax/esm/createPageConfig.js');
+var createNativeComponent = require('../npm/remax/esm/createNativeComponent.js');
 require('../npm/remax/esm/index.js');
 var View = require('../npm/remax/esm/adapters/alipay/components/View.js');
 require('../npm/remax/esm/adapters/alipay/components/ScrollView.js');
@@ -45,6 +46,8 @@ require('../npm/remax/esm/adapters/alipay/components/Lifestyle.js');
 require('../npm/remax/esm/adapters/alipay/components/ContactButton.js');
 require('../npm/remax/esm/adapters/alipay/components/Video.js');
 require('../npm/remax/esm/adapters/alipay/api.js');
+
+var A = createNativeComponent.default('a-0');
 
 var _class, _descriptor, _temp;
 
@@ -96,7 +99,7 @@ var c = new C();
 c.p = 'a';
 
 var _page = function _page() {
-  return React.createElement(View.default, null, timesTwo([1, 2, 3]), N.V, N.W, c.p);
+  return React.createElement(View.default, null, timesTwo([1, 2, 3]), N.V, N.W, c.p, React.createElement(A, null));
 };
 
 var index = Page(createPageConfig.default(_page));

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/pages/index.json
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/expected/pages/index.json
@@ -1,3 +1,5 @@
 {
-  "usingComponents": {}
+  "usingComponents": {
+    "a-0": "../components/a/index"
+  }
 }

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/src/components/a/index.axml
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/src/components/a/index.axml
@@ -1,0 +1,1 @@
+<view>a</view>

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/src/components/a/index.js
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/src/components/a/index.js
@@ -1,0 +1,1 @@
+Component({});

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/src/components/a/index.json
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/src/components/a/index.json
@@ -1,0 +1,3 @@
+{
+  "component": true
+}

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/src/index.d.ts
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/src/index.d.ts
@@ -1,0 +1,5 @@
+declare module '@/components/b';
+declare module '@/components/a';
+declare module '@/components/c';
+declare module '@/components/d';
+declare module '@/components/g';

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/src/pages/index.tsx
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/src/pages/index.tsx
@@ -14,10 +14,29 @@ function timesTwo(arr: number[]) {
   return arr.map(n => n * 2);
 }
 
+function readonly(target: any, name: any, descriptor: any) {
+  descriptor.writable = false;
+  return descriptor;
+}
+
+class C {
+  // eslint-disable-next-line
+  // @ts-ignore
+  @readonly
+  // eslint-disable-next-line
+  // @ts-ignore
+  p = 'p';
+}
+
+const c = new C();
+
+c.p = 'a';
+
 export default () => (
   <View>
     {timesTwo([1, 2, 3])}
     {N.V}
     {N.W}
+    {c.p}
   </View>
 );

--- a/packages/remax-cli/src/__tests__/fixtures/babelrc/src/pages/index.tsx
+++ b/packages/remax-cli/src/__tests__/fixtures/babelrc/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import A from '@/components/a';
 import { View } from 'remax/alipay';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -38,5 +39,6 @@ export default () => (
     {N.V}
     {N.W}
     {c.p}
+    <A />
   </View>
 );

--- a/packages/remax-cli/src/build/plugins/babel.ts
+++ b/packages/remax-cli/src/build/plugins/babel.ts
@@ -36,7 +36,7 @@ function processPresets(presets: ConfigItem[], babel: any, react: boolean) {
   if (remaxPresetIndex === -1) {
     presets.unshift(remaxPreset);
   } else {
-    presets[remaxPreset] = remaxPreset;
+    presets[remaxPresetIndex] = remaxPreset;
   }
 
   return presets;


### PR DESCRIPTION
```js

  presets: [
    [
      'remax',
      {
        typescript: {
          allowNamespaces: true,
        },
        'class-properties': {
          loose: true,
        },
        decorators: {
          legacy: true,
        },
      },
    ],
  ];
}
```