### PR TITLE
扩展了 当 CSS inline image 的时候，支持相对路径

### DIFF
--- a/packages/remax-cli/src/build/plugins/postcssUrl.ts
+++ b/packages/remax-cli/src/build/plugins/postcssUrl.ts
@@ -43,7 +43,7 @@ export default function postcssUrl(options: RemaxOptions) {
     url: options.postcss?.url?.inline ? 'inline' : copy,
     maxSize: options.postcss?.url?.maxSize ?? 8,
     fallback: copy,
-    basePath: path.resolve(options.cwd, options.rootDir),
+    basePath: options.postcss?.url?.relativePath ? undefined : path.resolve(options.cwd, options.rootDir),
     assetsPath: path.resolve(options.cwd, options.output),
   });
 }

--- a/packages/remax-cli/src/getConfig.ts
+++ b/packages/remax-cli/src/getConfig.ts
@@ -28,6 +28,7 @@ export interface RemaxOptions {
       filter?: boolean;
       useHash?: boolean;
       hashOptions?: 'method' | 'shrink' | 'append';
+      relativePath: boolean;
     };
     plugins?: PluginImpl[];
   };


### PR DESCRIPTION
通过在 remax.config 中增加了 /postcss/url/relativePath 配置项支持图片的相对路径。
默认采用以 src 为 root 的绝对路径，当 relativePath= true 的时候采用引用图片的样式文件的相对路径