### PR TITLE
fix(remax): 修复 initialEventState 记录的初始 currentEventId 错误的问题

### DIFF
--- a/packages/remax/src/SyntheticEvent/Pool.ts
+++ b/packages/remax/src/SyntheticEvent/Pool.ts
@@ -20,16 +20,20 @@ export default class SyntheticEventPool {
     );
   }
 
-  public initialEventState(eventType: string, eventId?: string) {
+  public initialEventState(
+    eventType: string,
+    eventId?: string,
+    currentEventID?: string
+  ) {
     if (!this.state[eventType]) {
       this.state[eventType] = {};
     }
 
-    if (eventId) {
+    if (eventId && currentEventID) {
       this.state[eventType] = {
         [eventId]: {
           propagationStopped: false,
-          currentEventId: eventId,
+          currentEventId: currentEventID,
         },
       };
     }

--- a/packages/remax/src/SyntheticEvent/index.ts
+++ b/packages/remax/src/SyntheticEvent/index.ts
@@ -90,7 +90,7 @@ export function createCallbackProxy(
 
     if (isNewEvent(eventType, nativeEvent)) {
       // 新的事件流，初始化 store 数据
-      eventPool.initialEventState(eventType, eventId);
+      eventPool.initialEventState(eventType, eventId, currentEventId);
     } else {
       // 记录当前冒泡到的事件 ID
       eventPool.setLatestEvent(eventType, eventId, currentEventId);

--- a/packages/remax/src/__tests__/SyntheticEvent.test.ts
+++ b/packages/remax/src/__tests__/SyntheticEvent.test.ts
@@ -326,5 +326,30 @@ describe('synthetic event', () => {
 
       expect(bar).toBeCalledTimes(2);
     });
+
+    it('invoke parent onClick callback every time with stopPropagation called', () => {
+      const foo = jest.fn(e => {
+        e.stopPropagation();
+      });
+      const fooProxy = createCallbackProxy('onClick', foo);
+
+      const event = {
+        target: {
+          dataset: {
+            rid: 1,
+          },
+        },
+        currentTarget: {
+          dataset: {
+            rid: 2,
+          },
+        },
+      };
+
+      fooProxy(event);
+      fooProxy(event);
+
+      expect(foo).toBeCalledTimes(2);
+    });
   });
 });


### PR DESCRIPTION
修复 issue #552 

目前破坏了 `do not stop propagation when unexpected event happens` 测试用例。不太理解这个用例的目的是什么，看起来没什么意义，望告知。