### PR TITLE
fix: 修正头条小程序button组件onGetPhoneNumber事件大小写拼写问题

### DIFF
--- a/packages/remax-toutiao/src/hostComponents/Button/index.ts
+++ b/packages/remax-toutiao/src/hostComponents/Button/index.ts
@@ -14,7 +14,7 @@ export interface ButtonProps extends BaseProps {
   formType?: 'submit' | 'reset';
   openType?: 'share' | 'getPhoneNumber';
   onClick?: (e: any) => void;
-  onGetphonenumber?: (e: any) => void;
+  onGetPhoneNumber?: (e: any) => void;
 }
 
 export default createHostComponent<ButtonProps>('button');


### PR DESCRIPTION
如题，简单修改onGetPhoneNumber事件名，会导致现有项目onGetphonenumber事件失效