### PR TITLE
fix: 修复环境变量注入导致的语法错误

### DIFF
--- a/packages/remax-cli/src/__tests__/fixtures/env/expected/pages/index.js
+++ b/packages/remax-cli/src/__tests__/fixtures/env/expected/pages/index.js
@@ -46,9 +46,8 @@ require('../npm/remax/npm/remax-alipay/esm/hostComponents/Video/index.js');
 require('../npm/remax/npm/remax-alipay/esm/api/index.js');
 
 var _page = function _page() {
-  var REMAX_APP_HELLO = ({"NODE_ENV":"test","REMAX_APP_HELLO":"hello","REMAX_APP_MESSAGE":"hello world"}).REMAX_APP_HELLO;
 
-  return React.createElement(index$2.default, null, React.createElement(index$b.default, null, ({"NODE_ENV":"test","REMAX_APP_HELLO":"hello","REMAX_APP_MESSAGE":"hello world"}).NODE_ENV), React.createElement(index$b.default, null, REMAX_APP_HELLO), React.createElement(index$b.default, null, ({"NODE_ENV":"test","REMAX_APP_HELLO":"hello","REMAX_APP_MESSAGE":"hello world"}).REMAX_APP_MESSAGE));
+  return React.createElement(index$2.default, null, React.createElement(index$b.default, null, "test"), React.createElement(index$b.default, null, "hello"), React.createElement(index$b.default, null, "hello world"));
 };
 
 var index = Page(createPageConfig.default(_page));

--- a/packages/remax-cli/src/__tests__/fixtures/env/src/pages/index.js
+++ b/packages/remax-cli/src/__tests__/fixtures/env/src/pages/index.js
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { View, Text } from 'remax/alipay';
 
 export default () => {
-  const { REMAX_APP_HELLO } = process.env;
-
   if (process.env.NODE_ENV === 'production') {
     console.log('bazinga!');
   }
@@ -11,7 +9,7 @@ export default () => {
   return (
     <View>
       <Text>{process.env.NODE_ENV}</Text>
-      <Text>{REMAX_APP_HELLO}</Text>
+      <Text>{process.env.REMAX_APP_HELLO}</Text>
       <Text>{process.env.REMAX_APP_MESSAGE}</Text>
     </View>
   );

--- a/packages/remax-cli/src/build/env.ts
+++ b/packages/remax-cli/src/build/env.ts
@@ -55,15 +55,10 @@ export default function getEnvironment(options: RemaxOptions, target: string) {
     }, builtiEnv);
 
   const stringified = {
-    'process.env': () =>
-      '(' +
-      JSON.stringify(
-        Object.keys(raw).reduce((env: Env, key) => {
-          env[key] = raw[key];
-          return env;
-        }, {})
-      ) +
-      ')',
+    ...Object.keys(raw).reduce((env: Env, key) => {
+      env[`process.env.${key}`] = JSON.stringify(raw[key]);
+      return env;
+    }, {}),
     __REMAX_DEBUG__: JSON.stringify(process.env.REMAX_DEBUG),
     __REMAX_PX2RPX__: JSON.stringify(options.pxToRpx),
     __REMAX_HOST_COMPONENTS__: () => stringifyHostComponents(),


### PR DESCRIPTION
直接替换 `process.env` 会匹配到 `g.process.env` 导致语法错误。
比如：node_modules/lib/mobx.module.js