### PR TITLE
feat(cli): 支持 css modules 更多配置

### DIFF
--- a/packages/remax-cli/src/build/rollupConfig.ts
+++ b/packages/remax-cli/src/build/rollupConfig.ts
@@ -130,7 +130,10 @@ export default function rollupConfig(
         'app' + API.getMeta().style
       ),
       ...postcssConfig.options,
-      modules: cssModuleConfig,
+      modules: {
+        ...cssModuleConfig,
+        ...postcssConfig.options.modules,
+      },
       plugins: [options.pxToRpx && pxToUnits(), postcssUrl(options)]
         .filter(Boolean)
         .concat(postcssConfig.plugins),


### PR DESCRIPTION
在 [postcss-modules](https://github.com/css-modules/postcss-modules) 中，可以看到 `modules` 是可以配置额外的参数的，例如
```js
{
  modules: {
    generateScopedName: "[name]__[local]___[hash:base64:5]"
  }
}
```
而目前只配置了 `globalModulePaths` 参数，无法配置更多的 `postcss-modules` 参数选项