### PR TITLE
更新webstorm下api类型无提示设置方法

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,7 +32,7 @@ Remax 支持直接使用原生组件库。具体请参考 [小程序自定义组
 
 原因是 remax-wechat 不是项目的直接依赖，WebStorm 就不会去索引它。所以我们进行以下操作即可（把 node_modules/remax-wechat 这个目录设置为 “not excluded” 就可以了。[相关issue链接](https://github.com/remaxjs/remax/issues/598)）
 
-<img width="800" src="https://user-images.githubusercontent.com/465125/72723587-f4310d80-3bbb-11ea-84d3-763866789678.jpg" />
+<img width="800" src="https://gw.alipayobjects.com/mdn/rms_a6d2d8/afts/img/A*HkStQ4JvAyYAAAAAAAAAAABkARQnAQ" />
 
 ## 使用高阶组件导致页面的生命周期未调用
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,9 +30,9 @@ Remax 支持直接使用原生组件库。具体请参考 [小程序自定义组
 
 ## Webstorm IDE编辑器下api类型无提示问题
 
-原因是 remax-wechat 不是项目的直接依赖，WebStorm 就不会去索引它。所以我们进行一下下面的操作即可（把 node_modules/remax-wechat 这个目录设置为 “not excluded” 就可以了。[相关issue链接](https://github.com/remaxjs/remax/issues/598)）
+原因是 remax-wechat 不是项目的直接依赖，WebStorm 就不会去索引它。所以我们进行以下操作即可（把 node_modules/remax-wechat 这个目录设置为 “not excluded” 就可以了。[相关issue链接](https://github.com/remaxjs/remax/issues/598)）
 
-![如图所示](https://user-images.githubusercontent.com/465125/72723587-f4310d80-3bbb-11ea-84d3-763866789678.jpg)
+<img width="800" src="https://gw.alipayobjects.com/mdn/rms_a6d2d8/afts/img/A*pExGT4kna-AAAAAAAAAAAABkARQnAQ" />
 
 
 ## 使用高阶组件导致页面的生命周期未调用

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,6 +28,13 @@ Remax 支持直接使用原生组件库。具体请参考 [小程序自定义组
 
 具体可参考 [跨平台开发](/guide/one)。
 
+## Webstorm IDE编辑器下api类型无提示问题
+
+原因是 remax-wechat 不是项目的直接依赖，WebStorm 就不会去索引它。所以我们进行一下下面的操作即可（把 node_modules/remax-wechat 这个目录设置为 “not excluded” 就可以了。[相关issue链接](https://github.com/remaxjs/remax/issues/598)）
+
+![如图所示](https://user-images.githubusercontent.com/465125/72723587-f4310d80-3bbb-11ea-84d3-763866789678.jpg)
+
+
 ## 使用高阶组件导致页面的生命周期未调用
 
 如果使用了 Redux 的 connect ，请将 connect 的 option.forwardRef 设置为 true[文档](https://react-redux.js.org/api/connect#forwardref-boolean)。其它第三方库的高阶组件的处理方式也类似。原因如下。

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,8 +32,7 @@ Remax 支持直接使用原生组件库。具体请参考 [小程序自定义组
 
 原因是 remax-wechat 不是项目的直接依赖，WebStorm 就不会去索引它。所以我们进行以下操作即可（把 node_modules/remax-wechat 这个目录设置为 “not excluded” 就可以了。[相关issue链接](https://github.com/remaxjs/remax/issues/598)）
 
-<img width="800" src="https://gw.alipayobjects.com/mdn/rms_a6d2d8/afts/img/A*pExGT4kna-AAAAAAAAAAAABkARQnAQ" />
-
+<img width="800" src="https://user-images.githubusercontent.com/465125/72723587-f4310d80-3bbb-11ea-84d3-763866789678.jpg" />
 
 ## 使用高阶组件导致页面的生命周期未调用
 


### PR DESCRIPTION
更新webstorm编辑器下使用Remax，webstorm无提示的设置方法，便于新人在入手Remax时候IDE没有提示的困惑。