### PR TITLE
chore: use rimraf in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   "devDependencies": {
     "@types/express": "^4.17.4",
     "@types/webpack-dev-middleware": "^3.7.0",
-    "lint-staged": ">=8"
+    "lint-staged": ">=8",
+    "rimraf": "^3.0.2"
   },
   "collective": {
     "type": "opencollective",

--- a/packages/babel-preset-remax/package.json
+++ b/packages/babel-preset-remax/package.json
@@ -8,8 +8,9 @@
   "license": "MIT",
   "private": false,
   "scripts": {
+    "clean": "rimraf lib",
     "watch": "tsc -w",
-    "prebuild": "rm -rf lib",
+    "prebuild": "npm run clean",
     "build": "tsc"
   },
   "bugs": {

--- a/packages/postcss-remax-tag/package.json
+++ b/packages/postcss-remax-tag/package.json
@@ -5,6 +5,9 @@
   "repository": "git@github.com:remaxjs/remax.git",
   "author": "Caihuanyu <eterlf41@gmail.com>",
   "license": "MIT",
+  "scripts": {
+    "clean": "echo \"ignore\""
+  },
   "devDependencies": {
     "postcss": "^7.0.27"
   },

--- a/packages/remax-ali/package.json
+++ b/packages/remax-ali/package.json
@@ -7,10 +7,11 @@
   "module": "./esm/index.js",
   "typings": "./esm/index.d.ts",
   "scripts": {
+    "clean": "rimraf cjs esm",
     "watch": "concurrently \"npm:watch:*\"",
     "watch:esm": "npm run build:esm -- -w",
     "watch:cjs": "npm run build:cjs -- -w",
-    "prebuild": "rm -rf cjs esm",
+    "prebuild": "npm run clean",
     "build": "npm run build:cjs && npm run build:esm",
     "build:cjs": "tsc",
     "build:esm": "tsc --module ESNext --outDir esm",

--- a/packages/remax-cli/package.json
+++ b/packages/remax-cli/package.json
@@ -19,8 +19,9 @@
   },
   "homepage": "https://remaxjs.org",
   "scripts": {
+    "clean": "rimraf lib",
     "watch": "tsc -w",
-    "prebuild": "rm -rf lib",
+    "prebuild": "npm run clean",
     "build": "tsc",
     "test": "jest",
     "test:debug": "npx --node-arg=--inspect-brk jest -i"

--- a/packages/remax-macro/package.json
+++ b/packages/remax-macro/package.json
@@ -4,10 +4,11 @@
   "description": "",
   "main": "lib/index.js",
   "scripts": {
+    "clean": "rimraf lib",
     "pretest": "npm run build",
     "test": "jest",
     "watch": "tsc -w",
-    "prebuild": "rimraf lib",
+    "prebuild": "npm run clean",
     "build": "tsc"
   },
   "keywords": [
@@ -31,7 +32,6 @@
     "babel-plugin-tester": "^8.0.1",
     "jest": "^26.0.1",
     "react": "^16.12.0",
-    "rimraf": "^3.0.0",
     "ts-jest": "^25.4.0",
     "typescript": "^3.7.3"
   },

--- a/packages/remax-one/package.json
+++ b/packages/remax-one/package.json
@@ -7,10 +7,11 @@
   "module": "./esm/index.js",
   "typings": "./esm/index.d.ts",
   "scripts": {
+    "clean": "rimraf cjs esm",
     "watch": "concurrently \"npm:watch:*\"",
     "watch:esm": "npm run build:esm -- -w",
     "watch:cjs": "npm run build:cjs -- -w",
-    "prebuild": "rm -rf cjs esm",
+    "prebuild": "npm run clean",
     "build": "npm run build:esm && npm run build:cjs",
     "postbuild": "node ./scripts/postbuild.js",
     "build:esm": "tsc --module ESNext --outDir esm",

--- a/packages/remax-router/package.json
+++ b/packages/remax-router/package.json
@@ -4,6 +4,9 @@
   "version": "2.0.4",
   "main": "index.js",
   "license": "MIT",
+  "scripts": {
+    "clean": "echo \"ignore\""
+  },
   "dependencies": {
     "history": "^4.10.1",
     "react-router-cache-route": "^1.8.4",

--- a/packages/remax-runtime/package.json
+++ b/packages/remax-runtime/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://remaxjs.org",
   "scripts": {
-    "clean": "rm -rf esm cjs",
+    "clean": "rimraf esm cjs",
     "watch": "concurrently \"npm:watch:*\"",
     "watch:esm": "npm run build:esm -- -w",
     "watch:cjs": "npm run build:cjs -- -w",

--- a/packages/remax-toutiao/package.json
+++ b/packages/remax-toutiao/package.json
@@ -7,10 +7,11 @@
   "module": "./esm/index.js",
   "typings": "./esm/index.d.ts",
   "scripts": {
+    "clean": "rimraf cjs esm",
     "watch": "concurrently \"npm:watch:*\"",
     "watch:esm": "npm run build:esm -- -w",
     "watch:cjs": "npm run build:cjs -- -w",
-    "prebuild": "rm -rf cjs esm",
+    "prebuild": "npm run clean",
     "build": "npm run build:cjs && npm run build:esm",
     "build:cjs": "tsc",
     "build:esm": "tsc --module ESNext --outDir esm",

--- a/packages/remax-types/package.json
+++ b/packages/remax-types/package.json
@@ -7,7 +7,7 @@
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "scripts": {
-    "clean": "rm -rf esm cjs",
+    "clean": "rimraf esm cjs",
     "watch": "concurrently \"npm:watch:*\"",
     "watch:esm": "npm run build:esm -- -w",
     "watch:cjs": "npm run build:cjs -- -w",

--- a/packages/remax-web/package.json
+++ b/packages/remax-web/package.json
@@ -14,10 +14,11 @@
     "url": "git+https://github.com/remaxjs/remax.git"
   },
   "scripts": {
+    "clean": "rimraf cjs esm",
     "watch": "concurrently \"npm:watch:*\"",
     "watch:esm": "npm run build:esm -- -w",
     "watch:cjs": "npm run build:cjs -- -w",
-    "prebuild": "rm -rf cjs esm",
+    "prebuild": "npm run clean",
     "build:cjs": "tsc",
     "build:esm": "tsc --module ESNext --outDir esm",
     "build": "npm run build:cjs && npm run build:esm",

--- a/packages/remax-wechat/package.json
+++ b/packages/remax-wechat/package.json
@@ -7,10 +7,11 @@
   "module": "./esm/index.js",
   "typings": "./esm/index.d.ts",
   "scripts": {
+    "clean": "rimraf cjs esm",
     "watch": "concurrently \"npm:watch:*\"",
     "watch:esm": "npm run build:esm -- -w",
     "watch:cjs": "npm run build:cjs -- -w",
-    "prebuild": "rm -rf cjs esm",
+    "prebuild": "npm run clean",
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc --module ESNext --outDir esm",
     "build:cjs": "tsc --module CommonJS --outDir cjs",

--- a/packages/remax/package.json
+++ b/packages/remax/package.json
@@ -21,6 +21,9 @@
     "url": "git+https://github.com/remaxjs/remax.git"
   },
   "homepage": "https://remaxjs.org",
+  "scripts": {
+    "clean": "echo \"ignore\""
+  },
   "dependencies": {
     "@remax/ali": "2.0.4",
     "@remax/cli": "2.0.4",

--- a/website/package.json
+++ b/website/package.json
@@ -3,6 +3,7 @@
   "name": "website",
   "version": "2.0.4",
   "scripts": {
+    "clean": "rimraf dist",
     "start": "dumi dev",
     "build": "dumi build",
     "postbuild": "echo remaxjs.org > dist/CNAME",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14276,7 +14276,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@3.0.2, rimraf@^3.0.0:
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
为 workspace 下的所有 package 增加了 clean（rimraf）
方便执行 `yarn workspaces run clean` 来重置编译结果