### PR TITLE
ci: use stable node version (v14)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 13.x]
+        node-version: [12.x, 14.x]
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9209882/82404497-06e91f80-9a94-11ea-962f-75f49227debc.png)


node 13 将在 06-01 结束维护