### PR TITLE
fix: 修复入口和页面文件重复应用babel.config.js中的配置

### DIFF
--- a/packages/remax-cli/src/build/webpack/config.mini.ts
+++ b/packages/remax-cli/src/build/webpack/config.mini.ts
@@ -105,7 +105,7 @@ export default function webpackConfig(api: API, options: Options, target: Platfo
     .loader('babel')
     .options({
       babelrc: false,
-      configFile: resolveBabelConfig(options),
+      configFile: false,
       usePlugins: [appEntry(app.filename), pageEntry(options, api)],
       reactPreset: false,
     });


### PR DESCRIPTION
#1157 

