### PR TITLE
FIX WebStrom 组件无法自动提示属性

### DIFF
--- a/packages/remax-one/src/hostComponents/Button/index.ts
+++ b/packages/remax-one/src/hostComponents/Button/index.ts
@@ -25,6 +25,6 @@ export interface ButtonProps extends React.AriaAttributes {
   onTap?: (event: TapEvent) => void;
 }
 
-const Button = createHostComponent<ButtonProps>('button', alias, defaults);
+const Button: React.ComponentType<ButtonProps> = createHostComponent<ButtonProps>('button', alias, defaults);
 
 export default Button;

--- a/packages/remax-one/src/hostComponents/Form/index.ts
+++ b/packages/remax-one/src/hostComponents/Form/index.ts
@@ -1,9 +1,10 @@
+import * as React from 'react';
 import createHostComponent from '../../createHostComponent';
 import defaults from './props/default';
 import { FormProps } from './props';
 
 export type { FormProps };
 
-const Form = createHostComponent<FormProps>('form', null, defaults);
+const Form: React.ComponentType<FormProps> = createHostComponent<FormProps>('form', null, defaults);
 
 export default Form;

--- a/packages/remax-one/src/hostComponents/Image/index.ts
+++ b/packages/remax-one/src/hostComponents/Image/index.ts
@@ -1,9 +1,10 @@
+import * as React from 'react';
 import createHostComponent from '../../createHostComponent';
 import ImageProps from './props';
 import defaults from './props/default';
 
 export type { ImageProps };
 
-const Image = createHostComponent<ImageProps>('image', null, defaults);
+const Image: React.ComponentType<ImageProps> = createHostComponent<ImageProps>('image', null, defaults);
 
 export default Image;

--- a/packages/remax-one/src/hostComponents/Label/index.ts
+++ b/packages/remax-one/src/hostComponents/Label/index.ts
@@ -1,6 +1,9 @@
+import * as React from 'react';
 import createHostComponent from '../../createHostComponent';
 import { LabelProps } from './props';
 
 export type { LabelProps };
 
-export default createHostComponent<LabelProps>('label', { htmlFor: 'for' });
+const Label: React.ComponentType<LabelProps> = createHostComponent<LabelProps>('label', { htmlFor: 'for' });
+
+export default Label;

--- a/packages/remax-one/src/hostComponents/Navigator/index.ts
+++ b/packages/remax-one/src/hostComponents/Navigator/index.ts
@@ -1,7 +1,10 @@
+import * as React from 'react';
 import createHostComponent from '../../createHostComponent';
 import { NavigatorProps } from './props';
 import defaults from './props/default';
 
 export type { NavigatorProps };
 
-export default createHostComponent<NavigatorProps>('navigator', null, defaults);
+const Navigator: React.ComponentType<NavigatorProps> = createHostComponent<NavigatorProps>('navigator', null, defaults);
+
+export default Navigator;

--- a/packages/remax-one/src/hostComponents/Navigator/props/index.ts
+++ b/packages/remax-one/src/hostComponents/Navigator/props/index.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 export { default as defaults } from './default';
 
 export interface NavigatorProps {

--- a/packages/remax-one/src/hostComponents/Text/index.ts
+++ b/packages/remax-one/src/hostComponents/Text/index.ts
@@ -1,9 +1,10 @@
+import * as React from 'react';
 import createHostComponent from '../../createHostComponent';
 import TextProps from './props';
 import defaults from './props/default';
 
 export type { TextProps };
 
-const Text = createHostComponent<TextProps>('text', null, defaults);
+const Text: React.ComponentType<TextProps> = createHostComponent<TextProps>('text', null, defaults);
 
 export default Text;

--- a/packages/remax-one/src/hostComponents/Text/props/index.ts
+++ b/packages/remax-one/src/hostComponents/Text/props/index.ts
@@ -1,4 +1,5 @@
 import { TapEvent } from '../../../types';
+import React from 'react';
 
 export { default as defaults } from './default';
 

--- a/packages/remax-one/src/hostComponents/View/index.ts
+++ b/packages/remax-one/src/hostComponents/View/index.ts
@@ -1,9 +1,10 @@
+import * as React from 'react';
 import createHostComponent from '../../createHostComponent';
 import ViewProps from './props';
 import defaults from './props/default';
 
 export type { ViewProps };
 
-const View = createHostComponent<ViewProps>('view', null, defaults);
+const View: React.ComponentType<ViewProps> = createHostComponent<ViewProps>('view', null, defaults);
 
 export default View;

--- a/packages/remax-one/src/hostComponents/WebView/index.ts
+++ b/packages/remax-one/src/hostComponents/WebView/index.ts
@@ -8,6 +8,6 @@ export interface WebViewProps extends React.AriaAttributes {
   onMessage?: (event: Event) => void;
 }
 
-const WebView = createHostComponent<WebViewProps>('web-view', null);
+const WebView: React.ComponentType<WebViewProps> = createHostComponent<WebViewProps>('web-view', null);
 
 export default WebView;


### PR DESCRIPTION
显示声明组件类型，以修复 tsc 编译时自动类型推导生成的类型文件导致 WebStorm 组件不能自动提示