### PR TITLE
feat: 自动识别并打包自定义微信小程序组件

### DIFF
--- a/packages/remax-cli/src/build/babel/page.ts
+++ b/packages/remax-cli/src/build/babel/page.ts
@@ -6,23 +6,51 @@ import { slash } from '@remax/shared';
 import { getPages } from '../../getEntries';
 import API from '../../API';
 
-function pageConfigExpression(path: NodePath<t.ExportDefaultDeclaration>, id: t.Identifier, name: string) {
-  const createId = addNamed(path, 'createPageConfig', '@remax/runtime');
-  const insert: Node[] = [
-    t.exportDefaultDeclaration(
-      t.callExpression(t.identifier('Page'), [t.callExpression(createId, [id, t.stringLiteral(name)])])
-    ),
-  ];
-  if (process.env.NODE_ENV === 'development') {
-    insert.unshift(
-      t.expressionStatement(
-        t.assignmentExpression(
-          '=',
-          t.memberExpression(id, t.identifier('displayName')),
-          t.stringLiteral(`Page[${name}]`)
+function pageConfigExpression(
+  path: NodePath<t.ExportDefaultDeclaration>,
+  id: t.Identifier,
+  name: string,
+  isComponent: boolean
+) {
+  let insert: Node[];
+  let createId;
+
+  if (isComponent) {
+    createId = addNamed(path, 'createComponentConfig', '@remax/runtime');
+    insert = [
+      t.exportDefaultDeclaration(
+        t.callExpression(t.identifier('Component'), [t.callExpression(createId, [id, t.stringLiteral(name)])])
+      ),
+    ];
+    if (process.env.NODE_ENV === 'development') {
+      insert.unshift(
+        t.expressionStatement(
+          t.assignmentExpression(
+            '=',
+            t.memberExpression(id, t.identifier('displayName')),
+            t.stringLiteral(`Component[${name}]`)
+          )
         )
-      )
-    );
+      );
+    }
+  } else {
+    createId = addNamed(path, 'createPageConfig', '@remax/runtime');
+    insert = [
+      t.exportDefaultDeclaration(
+        t.callExpression(t.identifier('Page'), [t.callExpression(createId, [id, t.stringLiteral(name)])])
+      ),
+    ];
+    if (process.env.NODE_ENV === 'development') {
+      insert.unshift(
+        t.expressionStatement(
+          t.assignmentExpression(
+            '=',
+            t.memberExpression(id, t.identifier('displayName')),
+            t.stringLiteral(`Page[${name}]`)
+          )
+        )
+      );
+    }
   }
   path.insertAfter(insert);
 }
@@ -30,10 +58,12 @@ function pageConfigExpression(path: NodePath<t.ExportDefaultDeclaration>, id: t.
 export default function page(options: Options, api: API) {
   let skip = false;
   let name = '';
+  let isComponent = false;
 
   return {
     pre(state: any) {
       name = getPages(options, api).find(e => e.filename === slash(state.opts.filename))?.name || '';
+      isComponent = (options.pages && options.pages.some(page => page.name === name && page.isComponent)) || false;
       skip = !name;
     },
     visitor: {
@@ -46,14 +76,14 @@ export default function page(options: Options, api: API) {
           const pageId = path.scope.generateUidIdentifier('page');
           const declaration = path.node.declaration;
           path.replaceWith(t.variableDeclaration('const', [t.variableDeclarator(pageId, declaration)]));
-          pageConfigExpression(path, pageId, name);
+          pageConfigExpression(path, pageId, name, isComponent);
           skip = true;
         } else if (t.isFunctionDeclaration(path.node.declaration) || t.isClassDeclaration(path.node.declaration)) {
           const declaration = path.node.declaration;
           const pageId = path.scope.generateUidIdentifierBasedOnNode(path.node);
           declaration.id = pageId;
           path.replaceWith(declaration);
-          pageConfigExpression(path, pageId, name);
+          pageConfigExpression(path, pageId, name, isComponent);
           skip = true;
         }
       },

--- a/packages/remax-cli/src/build/utils/nativeComponent.ts
+++ b/packages/remax-cli/src/build/utils/nativeComponent.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import path from 'path';
 import resolve from 'enhanced-resolve';
 import { slash } from '@remax/shared';
+import { Options } from '@remax/types';
 import Config from 'webpack-chain';
 
 export const getSourcePath = (source: string, importer: string, config: Config) => {
@@ -32,6 +33,25 @@ export const isNativeComponent = (sourcePath: string | null): boolean => {
   }
 
   return require(sourceJsonPath).component;
+};
+
+// 是否为用户原生自定义组件
+export const isUserNativeComponent = (sourcePath: string | null, options: Options): boolean => {
+  const pages = options.pages || [];
+  if (!sourcePath) {
+    return false;
+  }
+
+  return pages.some(page => page.originFilename === sourcePath);
+};
+
+export const isUserNativeRedirectPage = (sourcePath: string | null, options: Options): boolean => {
+  const pages = options.pages || [];
+  if (!sourcePath) {
+    return false;
+  }
+
+  return pages.some(page => page.filename === sourcePath && page.isComponent);
 };
 
 export const getPath = (from: string, to: string) => {

--- a/packages/remax-cli/src/build/webpack/loaders/nativeComponent/index.ts
+++ b/packages/remax-cli/src/build/webpack/loaders/nativeComponent/index.ts
@@ -1,7 +1,7 @@
 import utils from 'loader-utils';
 import { loader } from 'webpack';
 import { registerNativeComponent as register } from '@remax/macro';
-import { isNativeComponent } from '../../../utils/nativeComponent';
+import { isNativeComponent, isUserNativeComponent } from '../../../utils/nativeComponent';
 import getAssets from './getAssets';
 
 export default function nativeComponent(this: loader.LoaderContext, source: string) {
@@ -12,15 +12,17 @@ export default function nativeComponent(this: loader.LoaderContext, source: stri
   const resourcePath = this.resourcePath;
   const { remaxOptions, api } = utils.getOptions(this) as any;
 
-  if (!isNativeComponent(resourcePath)) {
+  if (!isNativeComponent(resourcePath) && !isUserNativeComponent(resourcePath, remaxOptions)) {
     return source;
   }
+  let assets: string[] = [];
+  if (isNativeComponent(resourcePath)) {
+    assets = getAssets(api, resourcePath, remaxOptions);
 
-  const assets = getAssets(api, resourcePath, remaxOptions);
-
-  assets.forEach(file => {
-    this.addDependency(file);
-  });
+    assets.forEach(file => {
+      this.addDependency(file);
+    });
+  }
 
   const type = register(resourcePath, '', assets);
 

--- a/packages/remax-cli/src/build/webpack/plugins/NativeFiles/createPageManifest.ts
+++ b/packages/remax-cli/src/build/webpack/plugins/NativeFiles/createPageManifest.ts
@@ -8,6 +8,7 @@ import * as cacheable from './cacheable';
 import { pageConfigFile } from '../../../utils/paths';
 import API from '../../../../API';
 import getUsingComponents from './getUsingComponents';
+import { isUserNativeRedirectPage } from '../../../utils/nativeComponent';
 
 export default function createPageManifest(
   options: Options,
@@ -22,6 +23,9 @@ export default function createPageManifest(
   const config = readManifest(pageConfigFile(page.filename, options), options.target!);
   const usingComponents = getUsingComponents(modules, options, compilation);
 
+  if (isUserNativeRedirectPage(page.filename, options)) {
+    config.component = true;
+  }
   config.usingComponents = {
     ...(config.usingComponents || {}),
     ...usingComponents,

--- a/packages/remax-cli/src/build/webpack/plugins/NativeFiles/getUsingComponents.ts
+++ b/packages/remax-cli/src/build/webpack/plugins/NativeFiles/getUsingComponents.ts
@@ -4,9 +4,10 @@ import { compilation } from 'webpack';
 import { Options } from '@remax/types';
 import { nativeComponents } from '@remax/macro';
 import { slash } from '@remax/shared';
-import { isPluginPath } from '../../../utils/nativeComponent';
+import { isPluginPath, isUserNativeComponent } from '../../../utils/nativeComponent';
 
 const NATIVE_COMPONENT_OUTPUT_DIR = 'remaxVendors';
+const NATIVE_COMPONENT_OUTPUT_SUFFIX = '_remax_com';
 
 function getNativeComponentAssetOutputPath(sourcePath: string, options: Options) {
   return (
@@ -20,12 +21,33 @@ function getNativeComponentAssetOutputPath(sourcePath: string, options: Options)
   );
 }
 
+function getUserNativeComponentAssetOutputPath(sourcePath: string, options: Options) {
+  const fileName = slash(sourcePath)
+    .replace(slash(options.cwd) + '/', '')
+    .replace(slash(options.rootDir) + '/', '')
+    .replace(/@/g, '_')
+    .replace(/node_modules/g, 'npm');
+  const ext = fileName.substring(fileName.lastIndexOf('.') + 1);
+  const noExt = fileName.substring(0, fileName.lastIndexOf('.'));
+
+  return `${noExt}${NATIVE_COMPONENT_OUTPUT_SUFFIX}${ext ? `.${ext}` : ''}`;
+}
+
 export default function getUsingComponents(modules: string[], options: Options, compilation: compilation.Compilation) {
   const components = Array.from(nativeComponents.values()).filter(component =>
     component.importers.some(importer => modules.includes(importer))
   );
 
   return components.reduce<any>((config, component) => {
+    // 自定义原生组件
+    if (isUserNativeComponent(component.sourcePath, options)) {
+      const usingPath = '/' + getUserNativeComponentAssetOutputPath(component.sourcePath, options);
+      const ext = path.extname(usingPath);
+      config[component.id] = usingPath.replace(new RegExp(`\\${ext}$`), '');
+
+      return config;
+    }
+
     component.assets.forEach(asset => {
       const assetPath = getNativeComponentAssetOutputPath(asset, options);
       const source = fs.readFileSync(asset);

--- a/packages/remax-cli/src/getEntries.ts
+++ b/packages/remax-cli/src/getEntries.ts
@@ -5,17 +5,20 @@ import { searchJSFile } from './build/utils/paths';
 import API from './API';
 import getAppConfig from './build/utils/getAppConfig';
 
+const NATIVE_COMPONENT_OUTPUT_SUFFIX = '_remax_com';
+
 export function getPages(options: Options, api: API): EntryInfo[] {
   const appConfig = getAppConfig(options, api);
   const ROOT_DIR = path.join(options.cwd, options.rootDir);
   const subPackages = appConfig.subPackages || appConfig.subpackages || [];
+  const nativeComponents = appConfig.nativeComponents || {};
 
   if (!appConfig.pages || appConfig.pages.length === 0) {
     throw new Error('app.config.js|ts 并未配置页面参数');
   }
 
   // 页面
-  const pages: Array<{ name: string; filename: string }> = appConfig.pages.reduce(
+  const pages: EntryInfo[] = appConfig.pages.reduce(
     (ret: EntryInfo[], page: string) => [
       ...ret,
       {
@@ -25,6 +28,21 @@ export function getPages(options: Options, api: API): EntryInfo[] {
     ],
     []
   );
+
+  // 自定义组件作为page进行打包
+  // isComponent进行标识 做差异化处理
+  nativeComponents.forEach((pageDir: string) => {
+    const newPageDir = `${pageDir}${NATIVE_COMPONENT_OUTPUT_SUFFIX}`;
+    const originFilename = slash(searchJSFile(path.join(ROOT_DIR, pageDir), options.target!));
+    const ext = originFilename.substring(originFilename.lastIndexOf('.') + 1);
+
+    pages.push({
+      name: newPageDir,
+      filename: `${slash(path.join(ROOT_DIR, newPageDir))}${ext ? `.${ext}` : ''}`,
+      originFilename: slash(searchJSFile(path.join(ROOT_DIR, pageDir), options.target!)),
+      isComponent: true,
+    });
+  });
 
   // 分包页面
   subPackages.forEach((pack: { pages: string[]; root: string }) => {

--- a/packages/remax-cli/src/getEntries.ts
+++ b/packages/remax-cli/src/getEntries.ts
@@ -11,7 +11,7 @@ export function getPages(options: Options, api: API): EntryInfo[] {
   const appConfig = getAppConfig(options, api);
   const ROOT_DIR = path.join(options.cwd, options.rootDir);
   const subPackages = appConfig.subPackages || appConfig.subpackages || [];
-  const nativeComponents = appConfig.nativeComponents || {};
+  const nativeComponents = appConfig.nativeComponents || [];
 
   if (!appConfig.pages || appConfig.pages.length === 0) {
     throw new Error('app.config.js|ts 并未配置页面参数');

--- a/packages/remax-runtime/src/createComponentConfig.ts
+++ b/packages/remax-runtime/src/createComponentConfig.ts
@@ -1,0 +1,112 @@
+import * as React from 'react';
+import render from './render';
+import * as RuntimeOptions from './RuntimeOptions';
+import createComponentWrapper from './createComponentWrapper';
+import { Lifecycle, callbackName } from './lifecycle';
+import Container from './Container';
+
+let idCounter = 0;
+
+function generatePageId() {
+  const id = idCounter;
+  const pageId = 'component_' + id;
+  idCounter += 1;
+  return pageId;
+}
+
+// for testing
+export function resetPageId() {
+  idCounter = 0;
+}
+
+export default function createPageConfig(Page: React.ComponentType<any>, name: string) {
+  const config: any = {
+    data: {
+      root: {},
+      modalRoot: {
+        children: [],
+      },
+    },
+    properties: {
+      // 仅解析data
+      data: {
+        type: Object,
+        value: {},
+        observer: function (newVal: any, oldVal: any) {
+          if (Object.keys(oldVal).length) {
+            // 解决component中 react顶层组件 props不更新问题
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
+            this.instance && this.instance.updateData(newVal || {});
+          }
+        },
+      },
+    },
+    lifetimes: {
+      attached: function (this: any) {
+        this.wrapperRef = React.createRef<any>();
+        this.lifecycleCallback = {};
+        const query = {};
+        const PageWrapper = createComponentWrapper(Page, name);
+        this.pageId = generatePageId();
+
+        this.query = query;
+
+        this.container = new Container(this, 'root');
+        this.modalContainer = new Container(this, 'modalRoot');
+
+        this.element = React.createElement(PageWrapper, {
+          page: this,
+          data: this.data.data || {},
+          modalContainer: this.modalContainer,
+          ref: this.wrapperRef,
+          getInstance: (node: any) => (this.instance = node),
+        });
+        render(this.element, this.container);
+
+        this.callLifecycle(Lifecycle.load, query);
+      },
+      moved: () => {},
+      detached: function (this: any) {
+        this.callLifecycle(Lifecycle.unload);
+        this.unloaded = true;
+        this.container.clearUpdate();
+      },
+    },
+    methods: {
+      /**
+       * Lifecycle start
+       */
+      registerLifecycle(this: any, lifecycle: Lifecycle, callback: () => any) {
+        this.lifecycleCallback[lifecycle] = this.lifecycleCallback[lifecycle] || [];
+
+        this.lifecycleCallback[lifecycle].push(callback);
+
+        return () => {
+          this.lifecycleCallback[lifecycle].splice(this.lifecycleCallback[lifecycle].indexOf(callback), 1);
+        };
+      },
+
+      callLifecycle(this: any, lifecycle: Lifecycle, ...args: any[]) {
+        console.log(lifecycle, ...args);
+        const callbacks = this.lifecycleCallback[lifecycle] || [];
+        let result;
+        callbacks.forEach((callback: any) => {
+          result = callback(...args);
+        });
+        if (result) {
+          return result;
+        }
+
+        const callback = callbackName(lifecycle);
+        if (this.wrapperRef.current && this.wrapperRef.current[callback]) {
+          return this.wrapperRef.current[callback](...args);
+        }
+      },
+    },
+  };
+
+  const pageObj = RuntimeOptions.get('pluginDriver').onPageConfig({ config, page: name });
+
+  return pageObj;
+}

--- a/packages/remax-runtime/src/createComponentWrapper.ts
+++ b/packages/remax-runtime/src/createComponentWrapper.ts
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import isClassComponent from './utils/isClassComponent';
+import { Lifecycle, Callback, callbackName } from './lifecycle';
+import { ForwardRef } from './ReactIs';
+import Container from './Container';
+import * as RuntimeOptions from './RuntimeOptions';
+
+export default function createPageWrapper(Page: React.ComponentType<any>, name: string) {
+  const WrappedPage = RuntimeOptions.get('pluginDriver').onPageComponent({ component: Page, page: name });
+
+  return class PageWrapper extends React.Component<{ page: any; data: any; modalContainer: Container }, any> {
+    // 页面组件的实例
+    pageComponentInstance: any = null;
+
+    callbacks = new Map<
+      string,
+      {
+        callbacks: Callback[];
+      }
+    >();
+
+    constructor(props: any) {
+      super(props);
+      props.getInstance(this);
+      Object.keys(Lifecycle).forEach(phase => {
+        const callback = callbackName(phase);
+        (this as any)[callback] = (...args: any[]) => {
+          return this.callLifecycle(phase, ...args);
+        };
+      });
+      this.state = {
+        data: null,
+      };
+    }
+
+    // 更新data
+    updateData(data: any) {
+      this.setState({ data });
+    }
+
+    callLifecycle(phase: string, ...args: any[]) {
+      const callback = callbackName(phase);
+      if (this.pageComponentInstance && typeof this.pageComponentInstance[callback] === 'function') {
+        return this.pageComponentInstance[callback](...args);
+      }
+    }
+
+    render() {
+      const { data } = this.state;
+      // 实例化时使用props传入的值 外层传入值更新时使用state中data
+      // 为了解决外层容器传入数据变化不更新问题
+      const props: any = { data: data || this.props.data };
+
+      if (isClassComponent(Page) || (Page as any).$$typeof === ForwardRef) {
+        props.ref = (node: any) => (this.pageComponentInstance = node);
+      }
+
+      return React.createElement(WrappedPage, props);
+    }
+  };
+}

--- a/packages/remax-runtime/src/index.ts
+++ b/packages/remax-runtime/src/index.ts
@@ -2,6 +2,7 @@ export { default as render } from './render';
 export { default as PluginDriver } from './PluginDriver';
 export { default as createAppConfig } from './createAppConfig';
 export { default as createPageConfig } from './createPageConfig';
+export { default as createComponentConfig } from './createComponentConfig';
 export { default as createNativeComponent } from './createNativeComponent';
 export { createPortal } from './ReactPortal';
 import * as RuntimeOptions from './RuntimeOptions';

--- a/packages/remax-types/src/index.ts
+++ b/packages/remax-types/src/index.ts
@@ -27,6 +27,7 @@ export interface Options {
   target?: Platform;
   analyze?: boolean;
   minimize?: boolean;
+  pages?: EntryInfo[];
 }
 
 export type Config = Partial<Options>;
@@ -34,6 +35,8 @@ export type Config = Partial<Options>;
 export interface EntryInfo {
   name: string;
   filename: string;
+  isComponent?: boolean;
+  originFilename?: string;
 }
 
 export interface Entries {


### PR DESCRIPTION
## 简单介绍
remax会将我们的页面直接打成小程序的page，每次数据更新导致setData时都是页面级别的diff和渲染。
如果页面节点较多或者频繁UI更新时可能出现卡顿和响应慢的情况。但是，remax官方仅支持使用原生小程序，不支持直接使用React编写原生小程序。对此我们做了一些改造，通过配置的方式将一些React编写的组件自动打包成微信的组件。

## 使用说明
需要在app.config.js中配置nativeComponents目录（和pages配置规则相同）。

```js
const nativeComponents = [
  'comp/todoList/index'
];
```
向组件中传递数据：由于小程序需要定义传入组件的类型（[微信自定义组件](https://developers.weixin.qq.com/miniprogram/dev/reference/api/Component.html)），所以框架内部只暴露了data传递渲染数据。非渲染数据以及一些function可以使用redux、mobx的方式直接注入组件
```js
<TodoList data={Object} />
```

## 改造说明
在remax打包基础上，区分出需要打包成component的逻辑。利用webpack-virtual-modules将component打包成带有特定后缀产物。自定义component的识别基本复用了原生component识别逻辑。区别在于原生的component有现成的产物，自定义component只是指向了component打包产物的路径。

## 欢迎联系
阅读remax的源码做的改动，可能有些地方疏忽了，有问题可以随时发邮件或者其他方式和我联系
电话：15600696795
邮箱：15600696795@163.com