### PR TITLE
fix(wechat app.config type fix): 修复微信小程序 app.config.ts 声明错误问题

### DIFF
--- a/packages/remax-wechat/src/types/config.ts
+++ b/packages/remax-wechat/src/types/config.ts
@@ -249,9 +249,9 @@ export interface AppConfig {
    * 1.7.3
    */
   subpackages?: Array<{
-    root: 'string';
-    name?: 'string';
-    pages: [];
+    root: string;
+    name?: string;
+    pages: string[];
     independent?: boolean;
   }>;
   /**


### PR DESCRIPTION
如题，在使用过程中，发现针对微信小程序的 app.json TS 声明有误，这里提供修复后的代码