### PR TITLE
docs: 修复plugin使用js接口文档可能有问题的点

### DIFF
--- a/docs/guide/basic/plugin.md
+++ b/docs/guide/basic/plugin.md
@@ -51,7 +51,7 @@ export default ()  => (
 ```javascript
 import { requirePlugin } from 'remax/macro';
 
-const myPlugin = requirePlugin('plugin://myPlugin/hello');
+const myPlugin = requirePlugin('myPlugin');
 
 myPlugin.hello();
 


### PR DESCRIPTION
修复plugin使用js接口文档可能有问题的点

实际上引用js 的接口的时候，都不是 `plugin://xxx ` 直接是组件名的