### PR TITLE
feat(cli): 支持dotenv自定义环境扩展

### DIFF
--- a/docs/guide/config/environment-variables.md
+++ b/docs/guide/config/environment-variables.md
@@ -74,3 +74,19 @@ REMAX_APP_BASE_URL=https://example.com/api
 DOMAIN=www.example.com
 REMAX_APP_API=$DOMAIN/api
 ```
+
+## 自定义启用dotenv的环境变量名称
+
+默认以 `NODE_ENV` 环境变量来区分加载 `dotenv` 文件配置，也可以配置项 `dotenvSymbol` 进行自定义
+
+启动命令：
+
+```shell
+APP_ENV=staging remax build -t ali
+```
+
+```js
+module.exports = {
+  dotenvSymbol: 'APP_ENV'
+}
+```

--- a/packages/remax-cli/src/OptionsSchema.json
+++ b/packages/remax-cli/src/OptionsSchema.json
@@ -33,6 +33,9 @@
     },
     "plugins": {
       "type": "array"
+    },
+    "dotenvSymbol": {
+      "type": "string"
     }
   },
   "additionalProperties": false

--- a/packages/remax-cli/src/__tests__/integration/__snapshots__/config.test.ts.snap
+++ b/packages/remax-cli/src/__tests__/integration/__snapshots__/config.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`remax config schema validation 1`] = `
 "Invalid configuration object. remax has been initialized using a configuration object that does not match the API schema.
  - configuration has an unknown property 'xxx'. These properties are valid:
-   object { turboPages?, pxToRpx?, cwd?, progress?, compressTemplate?, output?, rootDir?, UNSAFE_wechatTemplateDepth?, one?, configWebpack?, plugins? }
+   object { turboPages?, pxToRpx?, cwd?, progress?, compressTemplate?, output?, rootDir?, UNSAFE_wechatTemplateDepth?, one?, configWebpack?, plugins?, dotenvSymbol? }
  - configuration.turboPages should be an array:
    [any, ...]
  - configuration.pxToRpx should be a boolean.
@@ -20,5 +20,6 @@ exports[`remax config schema validation 1`] = `
     * configuration.UNSAFE_wechatTemplateDepth should be a number.
  - configuration.configWebpack should be an instance of function.
  - configuration.plugins should be an array:
-   [any, ...]"
+   [any, ...]
+ - configuration.dotenvSymbol should be a string."
 `;

--- a/packages/remax-cli/src/__tests__/integration/fixtures/exception/remax.config/remax.config.js
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/exception/remax.config/remax.config.js
@@ -10,4 +10,5 @@ module.exports = {
   compressTemplate: 1,
   configWebpack: 1,
   plugins: 1,
+  dotenvSymbol: 1,
 };

--- a/packages/remax-cli/src/build/utils/env.ts
+++ b/packages/remax-cli/src/build/utils/env.ts
@@ -8,11 +8,12 @@ export default function getEnvironment(options: Options, target: string) {
   const envFilePath = path.join(options.cwd, '.env');
 
   const NODE_ENV = process.env.NODE_ENV;
+  const dotenvSymbol = process.env[options.dotenvSymbol || 'NODE_ENV'];
 
   // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
   const dotenvFiles = [
-    `${envFilePath}.${NODE_ENV}.local`,
-    `${envFilePath}.${NODE_ENV}`,
+    `${envFilePath}.${dotenvSymbol}.local`,
+    `${envFilePath}.${dotenvSymbol}`,
     // Don't include `.env.local` for `test` environment
     // since normally you expect tests to produce the same
     // results for everyone

--- a/packages/remax-cli/src/defaultOptions/index.ts
+++ b/packages/remax-cli/src/defaultOptions/index.ts
@@ -13,5 +13,6 @@ export function getDefaultOptions(): Options {
     UNSAFE_wechatTemplateDepth,
     plugins: [],
     notify: false,
+    dotenvSymbol: 'NODE_ENV',
   };
 }

--- a/packages/remax-types/src/index.ts
+++ b/packages/remax-types/src/index.ts
@@ -27,6 +27,7 @@ export interface Options {
   target?: Platform;
   analyze?: boolean;
   minimize?: boolean;
+  dotenvSymbol?: string;
 }
 
 export type Config = Partial<Options>;


### PR DESCRIPTION
当前有多个环境（dev, release1, release2,  staging,  test, production），而我看到 `remax-cli` 中比较多的构建配置项依赖 `process.env.NODE_ENV`，而当前除了 dev 是本地开发环境，其他都需要真实生产环境（或者构建过程和生产构建过程一致）。所以期望 dotenv 能够依赖某一个环境变量进行环境配置文件加载。那么现在有两种方式：

- 在 remax.config.js 中重新配置 definePlugin
- 加入自定义dotenv的环境变量标志

感觉和我当前的场景还是有比较多的，所以直接提个pr好了