### PR TITLE
fix: 修复 configWebpack 无法修改 plugins 里配置的问题

### DIFF
--- a/packages/remax-cli/src/build/webpack/config.mini.ts
+++ b/packages/remax-cli/src/build/webpack/config.mini.ts
@@ -218,11 +218,11 @@ export default function webpackConfig(api: API, options: Options, target: Platfo
     },
   };
 
+  api.configWebpack(context);
+
   if (typeof options.configWebpack === 'function') {
     options.configWebpack(context);
   }
-
-  api.configWebpack(context);
 
   const externals = config.get('externals');
   const runtimeOptionsExternal = {

--- a/packages/remax-cli/src/build/webpack/config.web.ts
+++ b/packages/remax-cli/src/build/webpack/config.web.ts
@@ -123,11 +123,11 @@ export default function webpackConfig(api: API, options: Options): webpack.Confi
     },
   };
 
+  api.configWebpack(context);
+
   if (typeof options.configWebpack === 'function') {
     options.configWebpack(context);
   }
-
-  api.configWebpack(context);
 
   const devServer = config.get('devServer') || {};
 


### PR DESCRIPTION
```js
// remax.config.js
{
  plugins: [require('@remax/plugin-less')],
  configWebpack({config }){
    // 此时无法修改 plugin 的配置
  }
}