### PR TITLE
fix: 修复swiper-item 添加class不生效问题

### DIFF
--- a/packages/remax-cli/src/__tests__/integration/fixtures/createHostComponent/expected/wechat/base.wxml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/createHostComponent/expected/wechat/base.wxml
@@ -1936,7 +1936,7 @@ skip-hidden-item-layout="{{_h.v(i.props['skip-hidden-item-layout'])}}"
 style="{{_h.v(i.props['style'])}}"
 vertical="{{_h.v(i.props['vertical'])}}">
     <block wx:for="{{i.children}}" wx:key="*this">
-  <swiper-item item-id="{{i.nodes[item].props.itemId}}" key="{{i.nodes[item].props.key}}">
+  <swiper-item class="{{i.nodes[item].props.class}}" item-id="{{i.nodes[item].props.itemId}}" key="{{i.nodes[item].props.key}}">
     <block wx:for="{{i.nodes[item].children}}" wx:key="*this" wx:for-item="sItem">
       <template is="{{'REMAX_TPL_' + (tid + 1) + '_CONTAINER'}}" data="{{i: i.nodes[item].nodes[sItem], a: a, tid: tid + 1 }}" />
     </block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/one/expected/wechat/base.wxml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/one/expected/wechat/base.wxml
@@ -1746,7 +1746,7 @@ skip-hidden-item-layout="{{_h.v(i.props['skip-hidden-item-layout'])}}"
 style="{{_h.v(i.props['style'])}}"
 vertical="{{_h.v(i.props['vertical'])}}">
     <block wx:for="{{i.children}}" wx:key="*this">
-  <swiper-item item-id="{{i.nodes[item].props.itemId}}" key="{{i.nodes[item].props.key}}">
+  <swiper-item class="{{i.nodes[item].props.class}}" item-id="{{i.nodes[item].props.itemId}}" key="{{i.nodes[item].props.key}}">
     <block wx:for="{{i.nodes[item].children}}" wx:key="*this" wx:for-item="sItem">
       <template is="{{'REMAX_TPL_' + (tid + 1) + '_CONTAINER'}}" data="{{i: i.nodes[item].nodes[sItem], a: a, tid: tid + 1 }}" />
     </block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/typescript/expected/wechat/base.wxml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/typescript/expected/wechat/base.wxml
@@ -1746,7 +1746,7 @@ skip-hidden-item-layout="{{_h.v(i.props['skip-hidden-item-layout'])}}"
 style="{{_h.v(i.props['style'])}}"
 vertical="{{_h.v(i.props['vertical'])}}">
     <block wx:for="{{i.children}}" wx:key="*this">
-  <swiper-item item-id="{{i.nodes[item].props.itemId}}" key="{{i.nodes[item].props.key}}">
+  <swiper-item class="{{i.nodes[item].props.class}}" item-id="{{i.nodes[item].props.itemId}}" key="{{i.nodes[item].props.key}}">
     <block wx:for="{{i.nodes[item].children}}" wx:key="*this" wx:for-item="sItem">
       <template is="{{'REMAX_TPL_' + (tid + 1) + '_CONTAINER'}}" data="{{i: i.nodes[item].nodes[sItem], a: a, tid: tid + 1 }}" />
     </block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/universe/expected/wechat/base.wxml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/universe/expected/wechat/base.wxml
@@ -1746,7 +1746,7 @@ skip-hidden-item-layout="{{_h.v(i.props['skip-hidden-item-layout'])}}"
 style="{{_h.v(i.props['style'])}}"
 vertical="{{_h.v(i.props['vertical'])}}">
     <block wx:for="{{i.children}}" wx:key="*this">
-  <swiper-item item-id="{{i.nodes[item].props.itemId}}" key="{{i.nodes[item].props.key}}">
+  <swiper-item class="{{i.nodes[item].props.class}}" item-id="{{i.nodes[item].props.itemId}}" key="{{i.nodes[item].props.key}}">
     <block wx:for="{{i.nodes[item].children}}" wx:key="*this" wx:for-item="sItem">
       <template is="{{'REMAX_TPL_' + (tid + 1) + '_CONTAINER'}}" data="{{i: i.nodes[item].nodes[sItem], a: a, tid: tid + 1 }}" />
     </block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/wechat/expected/base.wxml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/wechat/expected/base.wxml
@@ -1746,7 +1746,7 @@ skip-hidden-item-layout="{{_h.v(i.props['skip-hidden-item-layout'])}}"
 style="{{_h.v(i.props['style'])}}"
 vertical="{{_h.v(i.props['vertical'])}}">
     <block wx:for="{{i.children}}" wx:key="*this">
-  <swiper-item item-id="{{i.nodes[item].props.itemId}}" key="{{i.nodes[item].props.key}}">
+  <swiper-item class="{{i.nodes[item].props.class}}" item-id="{{i.nodes[item].props.itemId}}" key="{{i.nodes[item].props.key}}">
     <block wx:for="{{i.nodes[item].children}}" wx:key="*this" wx:for-item="sItem">
       <template is="{{'REMAX_TPL_' + (tid + 1) + '_CONTAINER'}}" data="{{i: i.nodes[item].nodes[sItem], a: a, tid: tid + 1 }}" />
     </block>

--- a/packages/remax-wechat/templates/children.ejs
+++ b/packages/remax-wechat/templates/children.ejs
@@ -1,6 +1,6 @@
 <%_ if (id === 'swiper') { _%>
 <block wx:for="{{i.children}}" wx:key="*this">
-  <swiper-item item-id="{{i.nodes[item].props.itemId}}" key="{{i.nodes[item].props.key}}">
+  <swiper-item class="{{i.nodes[item].props.class}}" item-id="{{i.nodes[item].props.itemId}}" key="{{i.nodes[item].props.key}}">
     <block wx:for="{{i.nodes[item].children}}" wx:key="*this" wx:for-item="sItem">
       <template is="{{'REMAX_TPL_' + (tid + 1) + '_CONTAINER'}}" data="{{i: i.nodes[item].nodes[sItem], a: a, tid: tid + 1 }}" />
     </block>


### PR DESCRIPTION
[#1369 ](url)

原生小程序是支持给swiper-item 添加class的，有场景可能需要动态操作它的样式