### PR TITLE
chore: trim empty lines and whitespaces in templates

### DIFF
--- a/packages/remax-ali/templates/default/base.ejs
+++ b/packages/remax-ali/templates/default/base.ejs
@@ -4,17 +4,17 @@
   </block>
 </template>
 
-<% for (let component of components) { %>
-  <% if (component.type !== 'native') { %>
+<% for (let component of components) { -%>
+  <%_ if (component.type !== 'native') { -%>
 <%- include('./native-component.ejs', {
-  props: component.props,
-  id: component.id,
-  slotView: slotView,
-  type: component.type,
-  })
-%>
-  <% } %>
-<% } %>
+      props: component.props,
+      id: component.id,
+      slotView: slotView,
+      type: component.type,
+    })
+-%>
+  <%_ } -%>
+<% } -%>
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-ali/templates/default/component.ejs
+++ b/packages/remax-ali/templates/default/component.ejs
@@ -1,33 +1,38 @@
 <template name="REMAX_TPL_1_<%=id%>">
-  <<%=id%> <% for(let i=0;i < props.length; i++) { %>
-    <% if (props[i] === 'key') { %>
+  <<%=id%>
+<% for(let i=0;i < props.length; i++) { -%>
+  <%_ if (props[i] === 'key') { -%>
     key="{{item.props.__key}}"
-    <% } else { %>
+  <%_ } else { -%>
     <%=props[i]%>="{{item.props['<%=props[i]%>']}}"
-    <% } %>
-    <% } %>
-    <% if (type === 'native') { %>ref="{{item.props['__ref']}}"<% } %>
+  <%_ } -%>
+<% } -%>
+    <%_ if (type === 'native') { -%>
+    ref="{{item.props['__ref']}}"
+    <%_ } -%>
   >
-    <% if (id === 'swiper') { %>
+    <%_ if (id === 'swiper') { -%>
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item <% for(let i=0;i < components.get('swiper-item').props.length; i++) { %>
-         <%=components.get('swiper-item').props[i]%>="{{item.props['<%=components.get('swiper-item').props[i]%>']}}" <% } %>
+      <swiper-item
+      <%_ for(let i=0;i < components.get('swiper-item').props.length; i++) { -%>
+        <%=components.get('swiper-item').props[i]%>="{{item.props['<%=components.get('swiper-item').props[i]%>']}}"
+      <%_ } -%>
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    <% } else if (id === 'text') { %>
+    <%_ } else if (id === 'text') { %>
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    <% } else if (id === 'picker') { %>
+    <%_ } else if (id === 'picker') { -%>
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    <% } else if (id === 'picker-view') { %>
+    <%_ } else if (id === 'picker-view') { -%>
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -35,11 +40,14 @@
         </view>
       </picker-view-column>
     </block>
-    <% } else if (type === 'native') { %>
+    <%_ } else if (type === 'native') { -%>
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.props['slot']}}">
-        <view slot="{{item.props['slot']}}" <% for(let i=0;i < slotView.props.length; i++) { %>
-          <%=slotView.props[i]%>="{{item.props['<%=slotView.props[i]%>']}}" <% } %>
+        <view
+          slot="{{item.props['slot']}}"
+          <%_ for(let i=0;i < slotView.props.length; i++) { -%>
+          <%=slotView.props[i]%>="{{item.props['<%=slotView.props[i]%>']}}"
+          <%_ } -%>
         >
           <block a:for="{{item.children}}" key="{{item.id}}">
             <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
@@ -50,10 +58,10 @@
         <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
       </block>
     </block>
-    <% } else { %>
+    <%_ } else { -%>
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    <% } %>
+    <%_ } -%>
   </<%=id%>>
 </template>

--- a/packages/remax-ali/templates/default/page.ejs
+++ b/packages/remax-ali/templates/default/page.ejs
@@ -6,20 +6,21 @@
   </block>
 </template>
 
-<% for (let component of sortBy(Array.from(components.values()), 'id')) { %>
-  <% if (skipComponents.includes(component.id)) {
+<% for (let component of sortBy(Array.from(components.values()), 'id')) { -%>
+  <%_ if (skipComponents.includes(component.id)) {
     continue;
-   } else { %>
-  <%- include('./component.ejs', {
-          components: components,
-          type: component.type,
-          props: component.props,
-          id: component.id,
-          slotView: slotView
-        }) %>
-  <% } %>
-  <% } %>
+   } else { -%>
+<%- include('./component.ejs', {
+      components: components,
+      type: component.type,
+      props: component.props,
+      id: component.id,
+      slotView: slotView
+    })
+-%>
 
+ <%_ } -%>
+<% } -%>
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>
 </template>

--- a/packages/remax-ali/templates/static/additional-host-component.ejs
+++ b/packages/remax-ali/templates/static/additional-host-component.ejs
@@ -1,6 +1,8 @@
 <template name="TPL_<%=id%>">
-  <<%=id%> <% for (let i = 0; i < props.length; i++) { %>
-    <%=props[i]%>="{{node.props['<%=props[i]%>']}}" <% } %>
+  <<%=id%>
+<% for (let i = 0; i < props.length; i++) { -%>
+    <%=props[i]%>="{{node.props['<%=props[i]%>']}}"
+<% } -%>
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </<%=id%>>

--- a/packages/remax-ali/templates/static/isolated-templates.ejs
+++ b/packages/remax-ali/templates/static/isolated-templates.ejs
@@ -1,4 +1,4 @@
-<% for (let tpl of templates) { %>
+<% for (let tpl of templates) { -%>
 <template name="TPL_<%=tpl.id%>">
   <%-tpl.template%>
 </template>

--- a/packages/remax-ali/templates/static/native-component.ejs
+++ b/packages/remax-ali/templates/static/native-component.ejs
@@ -1,11 +1,16 @@
 <template name="TPL_<%=id%>">
-  <<%=id%> <% for(let i=0;i < props.length; i++) { %>
-    <%=props[i]%>="{{node.props['<%=props[i]%>']}}"<% } %>
-    ref="{{node.props['__ref']}}">
+  <<%=id%>
+  <%_ for(let i=0;i < props.length; i++) { -%>
+    <%=props[i]%>="{{node.props['<%=props[i]%>']}}"
+  <%_ } -%>
+    ref="{{node.props['__ref']}}"
+  >
     <block a:for="{{node.children}}" key="{{item.id}}">
       <block a:if="{{item.props['slot']}}">
-        <view slot="{{item.props['slot']}}" <% for(let i=0;i < slotView.props.length; i++) { %>
-          <%=slotView.props[i]%>="{{item.props['<%=slotView.props[i]%>']}}" <% } %>
+        <view slot="{{item.props['slot']}}"
+        <%_ for(let i=0;i < slotView.props.length; i++) { -%>
+          <%=slotView.props[i]%>="{{item.props['<%=slotView.props[i]%>']}}"
+        <%_ } -%>
         >
           <template is="TPL_TRAVERSAL" data="{{root: item}}" />
         </view>

--- a/packages/remax-ali/templates/static/page.ejs
+++ b/packages/remax-ali/templates/static/page.ejs
@@ -1,49 +1,49 @@
-<% if (renderIsolatedTemplates) { %>
+<% if (renderIsolatedTemplates) { -%>
 <import src="/isolated.axml"/>
-<% } %>
+<% } -%>
 
-<% for (let tpl of templates) { %>
+<% for (let tpl of templates) { -%>
 <template name="TPL_<%=tpl.id%>">
   <%-tpl.template%>
 </template>
-<% } %>
 
-<% for (let component of sortBy(Array.from(components.values()), 'id')) { %>
-  <% if (skipComponents.includes(component.id)) {
+<% } -%>
+<% for (let component of sortBy(Array.from(components.values()), 'id')) { -%>
+  <%_ if (skipComponents.includes(component.id)) {
     continue;
-  } else if (component.additional) { %>
+  } else if (component.additional) { -%>
 <%- include('./additional-host-component.ejs', {
   props: component.props,
   id: component.id,
   slotView: slotView
   })
-%>
-  <% } else if (component.type === 'native') { %>
+-%>
+  <%_ } else if (component.type === 'native') { -%>
 <%- include('./native-component.ejs', {
   props: component.props,
   id: component.id,
   slotView: slotView,
   TEMPLATE_ID: TEMPLATE_ID
   })
-%>
-  <% } else { %>
+-%>
+  <%_ } else { -%>
 <%- include('./host-components/' + component.id + '.ejs', {
   components: components,
   props: component.props,
   id: component.id,
   })
-%>
-  <% } %>
-<% } %>
+-%>
+  <%_ } -%>
+<%_ } -%>
 
-<%- include('./host-components/plain-text.ejs') %>
-<%- include('./host-components/block.ejs') %>
+<%- include('./host-components/plain-text.ejs') -%>
+<%- include('./host-components/block.ejs') -%>
 
-<% if (entries.length > 0) { %>
-  <template is="TPL_<%=entries[0].id%>" data="{{ node: root.children[0] }}" />
-<% } else { %>
-  <template is="TPL_TRAVERSAL" data="{{ root: root }}" />
-<% } %>
+<% if (entries.length > 0) { -%>
+<template is="TPL_<%=entries[0].id%>" data="{{ node: root.children[0] }}" />
+<% } else { -%>
+<template is="TPL_TRAVERSAL" data="{{ root: root }}" />
+<% } -%>
 
 <!-- for default render -->
 <template name="TPL_DEFAULT">

--- a/packages/remax-cli/src/__tests__/integration/fixtures/ali/expected/packageA/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/ali/expected/packageA/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,959 +427,321 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     data-foo="{{item.props['data-foo']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     key="{{item.props.__key}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/ali/expected/pages/classPage.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/ali/expected/pages/classPage.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,959 +427,321 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     data-foo="{{item.props['data-foo']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     key="{{item.props.__key}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/ali/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/ali/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,959 +427,321 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     data-foo="{{item.props['data-foo']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     key="{{item.props.__key}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/assets/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/assets/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/babel-plugin-import/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/babel-plugin-import/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/babelrc/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/babelrc/expected/pages/index.axml
@@ -6,39 +6,37 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_a-index-20116ca">
-  <a-index-20116ca 
+<template name="REMAX_TPL_1_a-index-20116ca">
+  <a-index-20116ca
     ref="{{item.props['__ref']}}"
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.props['slot']}}">
-        <view slot="{{item.props['slot']}}" 
-          animation="{{item.props['animation']}}" 
-          class="{{item.props['class']}}" 
-          disable-scroll="{{item.props['disable-scroll']}}" 
-          hidden="{{item.props['hidden']}}" 
-          hover-class="{{item.props['hover-class']}}" 
-          hover-start-time="{{item.props['hover-start-time']}}" 
-          hover-stay-time="{{item.props['hover-stay-time']}}" 
-          hover-stop-propagation="{{item.props['hover-stop-propagation']}}" 
-          id="{{item.props['id']}}" 
-          onAnimationEnd="{{item.props['onAnimationEnd']}}" 
-          onAnimationIteration="{{item.props['onAnimationIteration']}}" 
-          onAnimationStart="{{item.props['onAnimationStart']}}" 
-          onAppear="{{item.props['onAppear']}}" 
-          onDisappear="{{item.props['onDisappear']}}" 
-          onFirstAppear="{{item.props['onFirstAppear']}}" 
-          onLongTap="{{item.props['onLongTap']}}" 
-          onTap="{{item.props['onTap']}}" 
-          onTouchCancel="{{item.props['onTouchCancel']}}" 
-          onTouchEnd="{{item.props['onTouchEnd']}}" 
-          onTouchMove="{{item.props['onTouchMove']}}" 
-          onTouchStart="{{item.props['onTouchStart']}}" 
-          onTransitionEnd="{{item.props['onTransitionEnd']}}" 
-          style="{{item.props['style']}}" 
+        <view
+          slot="{{item.props['slot']}}"
+          animation="{{item.props['animation']}}"
+          class="{{item.props['class']}}"
+          disable-scroll="{{item.props['disable-scroll']}}"
+          hidden="{{item.props['hidden']}}"
+          hover-class="{{item.props['hover-class']}}"
+          hover-start-time="{{item.props['hover-start-time']}}"
+          hover-stay-time="{{item.props['hover-stay-time']}}"
+          hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
+          id="{{item.props['id']}}"
+          onAnimationEnd="{{item.props['onAnimationEnd']}}"
+          onAnimationIteration="{{item.props['onAnimationIteration']}}"
+          onAnimationStart="{{item.props['onAnimationStart']}}"
+          onAppear="{{item.props['onAppear']}}"
+          onDisappear="{{item.props['onDisappear']}}"
+          onFirstAppear="{{item.props['onFirstAppear']}}"
+          onLongTap="{{item.props['onLongTap']}}"
+          onTap="{{item.props['onTap']}}"
+          onTouchCancel="{{item.props['onTouchCancel']}}"
+          onTouchEnd="{{item.props['onTouchEnd']}}"
+          onTouchMove="{{item.props['onTouchMove']}}"
+          onTouchStart="{{item.props['onTouchStart']}}"
+          onTransitionEnd="{{item.props['onTransitionEnd']}}"
+          style="{{item.props['style']}}"
         >
           <block a:for="{{item.children}}" key="{{item.id}}">
             <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
@@ -49,1242 +47,423 @@
         <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
       </block>
     </block>
-    
   </a-index-20116ca>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1292,951 +471,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/circularDependence/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/circularDependence/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/config-add-css-rule/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/config-add-css-rule/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/createHostComponent/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/createHostComponent/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/customCwdBabel/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/customCwdBabel/expected/pages/index.axml
@@ -6,39 +6,37 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_a-index-20116ca">
-  <a-index-20116ca 
+<template name="REMAX_TPL_1_a-index-20116ca">
+  <a-index-20116ca
     ref="{{item.props['__ref']}}"
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.props['slot']}}">
-        <view slot="{{item.props['slot']}}" 
-          animation="{{item.props['animation']}}" 
-          class="{{item.props['class']}}" 
-          disable-scroll="{{item.props['disable-scroll']}}" 
-          hidden="{{item.props['hidden']}}" 
-          hover-class="{{item.props['hover-class']}}" 
-          hover-start-time="{{item.props['hover-start-time']}}" 
-          hover-stay-time="{{item.props['hover-stay-time']}}" 
-          hover-stop-propagation="{{item.props['hover-stop-propagation']}}" 
-          id="{{item.props['id']}}" 
-          onAnimationEnd="{{item.props['onAnimationEnd']}}" 
-          onAnimationIteration="{{item.props['onAnimationIteration']}}" 
-          onAnimationStart="{{item.props['onAnimationStart']}}" 
-          onAppear="{{item.props['onAppear']}}" 
-          onDisappear="{{item.props['onDisappear']}}" 
-          onFirstAppear="{{item.props['onFirstAppear']}}" 
-          onLongTap="{{item.props['onLongTap']}}" 
-          onTap="{{item.props['onTap']}}" 
-          onTouchCancel="{{item.props['onTouchCancel']}}" 
-          onTouchEnd="{{item.props['onTouchEnd']}}" 
-          onTouchMove="{{item.props['onTouchMove']}}" 
-          onTouchStart="{{item.props['onTouchStart']}}" 
-          onTransitionEnd="{{item.props['onTransitionEnd']}}" 
-          style="{{item.props['style']}}" 
+        <view
+          slot="{{item.props['slot']}}"
+          animation="{{item.props['animation']}}"
+          class="{{item.props['class']}}"
+          disable-scroll="{{item.props['disable-scroll']}}"
+          hidden="{{item.props['hidden']}}"
+          hover-class="{{item.props['hover-class']}}"
+          hover-start-time="{{item.props['hover-start-time']}}"
+          hover-stay-time="{{item.props['hover-stay-time']}}"
+          hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
+          id="{{item.props['id']}}"
+          onAnimationEnd="{{item.props['onAnimationEnd']}}"
+          onAnimationIteration="{{item.props['onAnimationIteration']}}"
+          onAnimationStart="{{item.props['onAnimationStart']}}"
+          onAppear="{{item.props['onAppear']}}"
+          onDisappear="{{item.props['onDisappear']}}"
+          onFirstAppear="{{item.props['onFirstAppear']}}"
+          onLongTap="{{item.props['onLongTap']}}"
+          onTap="{{item.props['onTap']}}"
+          onTouchCancel="{{item.props['onTouchCancel']}}"
+          onTouchEnd="{{item.props['onTouchEnd']}}"
+          onTouchMove="{{item.props['onTouchMove']}}"
+          onTouchStart="{{item.props['onTouchStart']}}"
+          onTransitionEnd="{{item.props['onTransitionEnd']}}"
+          style="{{item.props['style']}}"
         >
           <block a:for="{{item.children}}" key="{{item.id}}">
             <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
@@ -49,1242 +47,423 @@
         <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
       </block>
     </block>
-    
   </a-index-20116ca>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1292,951 +471,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/customRootDir/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/customRootDir/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/env/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/env/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/hook-config-babel/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hook-config-babel/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/hook-config-webpack/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hook-config-webpack/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/hook-on-app-config/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hook-on-app-config/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/hook-on-page-config/expected/pages/about.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hook-on-page-config/expected/pages/about.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/hook-on-page-config/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hook-on-page-config/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/hook-on-page-template/expected/pages/about.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hook-on-page-template/expected/pages/about.axml
@@ -7,1237 +7,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1245,951 +428,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/hook-on-page-template/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hook-on-page-template/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-app/expected/pages/react/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-app/expected/pages/react/index.axml
@@ -6,16 +6,14 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_bar-index-8837ac4">
-  <bar-index-8837ac4 
+<template name="REMAX_TPL_1_bar-index-8837ac4">
+  <bar-index-8837ac4
     ref="{{item.props['__ref']}}"
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.props['slot']}}">
-        <view slot="{{item.props['slot']}}" 
+        <view
+          slot="{{item.props['slot']}}"
         >
           <block a:for="{{item.children}}" key="{{item.id}}">
             <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
@@ -26,457 +24,168 @@
         <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
       </block>
     </block>
-    
   </bar-index-8837ac4>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_foo-index-11b8f33">
-  <foo-index-11b8f33 
+<template name="REMAX_TPL_1_foo-index-11b8f33">
+  <foo-index-11b8f33
     ref="{{item.props['__ref']}}"
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.props['slot']}}">
-        <view slot="{{item.props['slot']}}" 
+        <view
+          slot="{{item.props['slot']}}"
         >
           <block a:for="{{item.children}}" key="{{item.id}}">
             <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
@@ -487,806 +196,272 @@
         <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
       </block>
     </block>
-    
   </foo-index-11b8f33>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1294,951 +469,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-mini-plugin/expected/components/react-greet/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-mini-plugin/expected/components/react-greet/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-mini-plugin/expected/pages/react/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-mini-plugin/expected/pages/react/index.axml
@@ -6,960 +6,334 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_mini-greet-index-774a1b6">
-  <mini-greet-index-774a1b6 
+<template name="REMAX_TPL_1_mini-greet-index-774a1b6">
+  <mini-greet-index-774a1b6
     ref="{{item.props['__ref']}}"
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.props['slot']}}">
-        <view slot="{{item.props['slot']}}" 
+        <view
+          slot="{{item.props['slot']}}"
         >
           <block a:for="{{item.children}}" key="{{item.id}}">
             <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
@@ -970,298 +344,103 @@
         <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
       </block>
     </block>
-    
   </mini-greet-index-774a1b6>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1269,951 +448,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/lifeCycle/expected/pages/classPage.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/lifeCycle/expected/pages/classPage.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/lifeCycle/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/lifeCycle/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/mini-plugin-basic/expected/components/greet/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/mini-plugin-basic/expected/components/greet/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,955 +427,320 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     data-foo="{{item.props['data-foo']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/mini-plugin-basic/expected/pages/index/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/mini-plugin-basic/expected/pages/index/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,955 +427,320 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     data-foo="{{item.props['data-foo']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/namespaceAttribute/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/namespaceAttribute/expected/pages/index.axml
@@ -6,1106 +6,381 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_native-component-index-f0e047f">
-  <native-component-index-f0e047f 
-    
+<template name="REMAX_TPL_1_native-component-index-f0e047f">
+  <native-component-index-f0e047f
     ns:prop="{{item.props['ns:prop']}}"
-    
-    
     ref="{{item.props['__ref']}}"
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.props['slot']}}">
-        <view slot="{{item.props['slot']}}" 
+        <view
+          slot="{{item.props['slot']}}"
         >
           <block a:for="{{item.children}}" key="{{item.id}}">
             <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
@@ -1116,156 +391,57 @@
         <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
       </block>
     </block>
-    
   </native-component-index-f0e047f>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1273,951 +449,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/reactDomAlias/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/reactDomAlias/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/regenerator-pkg/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/regenerator-pkg/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,959 +427,321 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     data-aspm-click="{{item.props['data-aspm-click']}}"
-    
-    
-    
     data-aspm-expo="{{item.props['data-aspm-expo']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/resolve-platform-ext/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/resolve-platform-ext/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/runtime-plugin-with-jsx/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/runtime-plugin-with-jsx/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/runtime-plugin/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/runtime-plugin/expected/pages/index.axml
@@ -6,1237 +6,420 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1244,951 +427,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/turbo-pages-basic/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/turbo-pages-basic/expected/pages/index.axml
@@ -6,1106 +6,381 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_native-component-index-f24c316">
-  <native-component-index-f24c316 
-    
+<template name="REMAX_TPL_1_native-component-index-f24c316">
+  <native-component-index-f24c316
     ns:attr="{{item.props['ns:attr']}}"
-    
-    
     ref="{{item.props['__ref']}}"
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.props['slot']}}">
-        <view slot="{{item.props['slot']}}" 
+        <view
+          slot="{{item.props['slot']}}"
         >
           <block a:for="{{item.children}}" key="{{item.id}}">
             <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
@@ -1116,156 +391,57 @@
         <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
       </block>
     </block>
-    
   </native-component-index-f24c316>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1273,955 +449,320 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     key="{{item.props.__key}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-cli/src/__tests__/integration/fixtures/turbo-pages-fragment-root/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/turbo-pages-fragment-root/expected/pages/index.axml
@@ -1,11 +1,5 @@
-
 <import src="/isolated.axml"/>
 
-
-
-
-
-  
 <template name="TPL_button">
   <button 
     app-parameter="{{node.props['app-parameter']}}" 
@@ -31,11 +25,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </button>
-</template>
-  
-
-  
-<template name="TPL_camera">
+</template><template name="TPL_camera">
   <camera 
     applyMicPermissionWhenInit="{{node.props['applyMicPermissionWhenInit']}}" 
     class="{{node.props['class']}}" 
@@ -55,10 +45,6 @@
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </camera>
 </template>
-
-  
-
-  
 <template name="TPL_canvas">
   <canvas 
     class="{{node.props['class']}}" 
@@ -77,11 +63,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </canvas>
-</template>
-  
-
-  
-<template name="TPL_checkbox">
+</template><template name="TPL_checkbox">
   <checkbox 
     checked="{{node.props['checked']}}" 
     class="{{node.props['class']}}" 
@@ -95,11 +77,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </checkbox>
-</template>
-  
-
-  
-<template name="TPL_checkbox-group">
+</template><template name="TPL_checkbox-group">
   <checkbox-group 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -109,11 +87,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </checkbox-group>
-</template>
-  
-
-  
-<template name="TPL_contact-button">
+</template><template name="TPL_contact-button">
   <contact-button 
     alipay-card-no="{{node.props['alipay-card-no']}}" 
     class="{{node.props['class']}}" 
@@ -127,11 +101,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </contact-button>
-</template>
-  
-
-  
-<template name="TPL_cover-image">
+</template><template name="TPL_cover-image">
   <cover-image 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -141,11 +111,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </cover-image>
-</template>
-  
-
-  
-<template name="TPL_cover-view">
+</template><template name="TPL_cover-view">
   <cover-view 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -154,11 +120,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </cover-view>
-</template>
-  
-
-  
-<template name="TPL_form">
+</template><template name="TPL_form">
   <form 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -169,11 +131,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </form>
-</template>
-  
-
-  
-<template name="TPL_icon">
+</template><template name="TPL_icon">
   <icon 
     class="{{node.props['class']}}" 
     color="{{node.props['color']}}" 
@@ -184,11 +142,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </icon>
-</template>
-  
-
-  
-<template name="TPL_image">
+</template><template name="TPL_image">
   <image 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -206,11 +160,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </image>
-</template>
-  
-
-  
-<template name="TPL_input">
+</template><template name="TPL_input">
   <input 
     class="{{node.props['class']}}" 
     confirm-hold="{{node.props['confirm-hold']}}" 
@@ -240,11 +190,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </input>
-</template>
-  
-
-  
-<template name="TPL_label">
+</template><template name="TPL_label">
   <label 
     class="{{node.props['class']}}" 
     for="{{node.props['for']}}" 
@@ -253,22 +199,14 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </label>
-</template>
-  
-
-  
-<template name="TPL_lifestyle">
+</template><template name="TPL_lifestyle">
   <lifestyle 
     onFollow="{{node.props['onFollow']}}" 
     public-id="{{node.props['public-id']}}" 
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </lifestyle>
-</template>
-  
-
-  
-<template name="TPL_lottie">
+</template><template name="TPL_lottie">
   <lottie 
     assetsPath="{{node.props['assetsPath']}}" 
     autoReverse="{{node.props['autoReverse']}}" 
@@ -293,10 +231,6 @@
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </lottie>
 </template>
-
-  
-
-  
 <template name="TPL_map">
   <map 
     circles="{{node.props['circles']}}" 
@@ -324,11 +258,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </map>
-</template>
-  
-
-  
-<template name="TPL_movable-area">
+</template><template name="TPL_movable-area">
   <movable-area 
     class="{{node.props['class']}}" 
     height="{{node.props['height']}}" 
@@ -338,11 +268,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </movable-area>
-</template>
-  
-
-  
-<template name="TPL_movable-view">
+</template><template name="TPL_movable-view">
   <movable-view 
     class="{{node.props['class']}}" 
     damping="{{node.props['damping']}}" 
@@ -370,11 +296,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </movable-view>
-</template>
-  
-
-  
-<template name="TPL_navigator">
+</template><template name="TPL_navigator">
   <navigator 
     class="{{node.props['class']}}" 
     hover-class="{{node.props['hover-class']}}" 
@@ -387,11 +309,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </navigator>
-</template>
-  
-
-  
-<template name="TPL_picker">
+</template><template name="TPL_picker">
   <picker 
     class="{{node.props['class']}}" 
     disabled="{{node.props['disabled']}}" 
@@ -408,10 +326,6 @@
     </view>
   </picker>
 </template>
-
-  
-
-  
 <template name="TPL_picker-view">
   <picker-view 
     class="{{node.props['class']}}" 
@@ -433,12 +347,7 @@
       </picker-view-column>
     </block>
   </picker-view>
-</template>
-  
-
-  
-  
-<template name="TPL_progress">
+</template><template name="TPL_progress">
   <progress 
     active="{{node.props['active']}}" 
     active-color="{{node.props['active-color']}}" 
@@ -452,11 +361,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </progress>
-</template>
-  
-
-  
-<template name="TPL_radio">
+</template><template name="TPL_radio">
   <radio 
     checked="{{node.props['checked']}}" 
     class="{{node.props['class']}}" 
@@ -469,11 +374,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </radio>
-</template>
-  
-
-  
-<template name="TPL_radio-group">
+</template><template name="TPL_radio-group">
   <radio-group 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -483,11 +384,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </radio-group>
-</template>
-  
-
-  
-<template name="TPL_rich-text">
+</template><template name="TPL_rich-text">
   <rich-text 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -502,11 +399,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </rich-text>
-</template>
-  
-
-  
-<template name="TPL_scroll-view">
+</template><template name="TPL_scroll-view">
   <scroll-view 
     class="{{node.props['class']}}" 
     enable-back-to-top="{{node.props['enable-back-to-top']}}" 
@@ -532,11 +425,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </scroll-view>
-</template>
-  
-
-  
-<template name="TPL_slider">
+</template><template name="TPL_slider">
   <slider 
     active-color="{{node.props['active-color']}}" 
     background-color="{{node.props['background-color']}}" 
@@ -558,11 +447,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </slider>
-</template>
-  
-
-  
-<template name="TPL_swiper">
+</template><template name="TPL_swiper">
   <swiper 
     acceleration="{{node.props['acceleration']}}" 
     active-class="{{node.props['active-class']}}" 
@@ -599,11 +484,6 @@
     </block>
   </swiper>
 </template>
-
-  
-
-  
-  
 <template name="TPL_switch">
   <switch 
     checked="{{node.props['checked']}}" 
@@ -618,11 +498,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </switch>
-</template>
-  
-
-  
-<template name="TPL_text">
+</template><template name="TPL_text">
   <text 
     class="{{node.props['class']}}" 
     decode="{{node.props['decode']}}" 
@@ -635,11 +511,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </text>
-</template>
-  
-
-  
-<template name="TPL_textarea">
+</template><template name="TPL_textarea">
   <textarea 
     auto-height="{{ node.props['auto-height'] }}" 
     class="{{ node.props['class'] }}" 
@@ -664,10 +536,6 @@
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </textarea>
 </template>
-
-  
-
-  
 <template name="TPL_video">
   <video 
     autoplay="{{node.props['autoplay']}}" 
@@ -702,11 +570,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </video>
-</template>
-  
-
-  
-<template name="TPL_view">
+</template><template name="TPL_view">
   <view 
     animation="{{node.props['animation']}}" 
     class="{{node.props['class']}}" 
@@ -734,11 +598,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </view>
-</template>
-  
-
-  
-<template name="TPL_web-view">
+</template><template name="TPL_web-view">
   <web-view 
     id="{{node.props['id']}}" 
     onMessage="{{node.props['onMessage']}}" 
@@ -747,22 +607,15 @@
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </web-view>
 </template>
-  
-
-
 <template name="TPL_plain-text">
   <block>{{ node.text }}</block>
 </template>
-
 <template name="TPL_block">
   <block>
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </block>
 </template>
-
-
-  <template is="TPL_TRAVERSAL" data="{{ root: root }}" />
-
+<template is="TPL_TRAVERSAL" data="{{ root: root }}" />
 
 <!-- for default render -->
 <template name="TPL_DEFAULT">

--- a/packages/remax-cli/src/__tests__/integration/fixtures/turbo-pages-picker-view/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/turbo-pages-picker-view/expected/pages/index.axml
@@ -1,7 +1,4 @@
-
 <import src="/isolated.axml"/>
-
-
 
 <template name="TPL_5da6971-1">
   <view ><template is="TPL_DEFAULT" data="{{root: node.children[0]}}" />
@@ -23,9 +20,6 @@
 
 </template>
 
-
-
-  
 <template name="TPL_button">
   <button 
     app-parameter="{{node.props['app-parameter']}}" 
@@ -51,11 +45,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </button>
-</template>
-  
-
-  
-<template name="TPL_camera">
+</template><template name="TPL_camera">
   <camera 
     applyMicPermissionWhenInit="{{node.props['applyMicPermissionWhenInit']}}" 
     class="{{node.props['class']}}" 
@@ -75,10 +65,6 @@
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </camera>
 </template>
-
-  
-
-  
 <template name="TPL_canvas">
   <canvas 
     class="{{node.props['class']}}" 
@@ -97,11 +83,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </canvas>
-</template>
-  
-
-  
-<template name="TPL_checkbox">
+</template><template name="TPL_checkbox">
   <checkbox 
     checked="{{node.props['checked']}}" 
     class="{{node.props['class']}}" 
@@ -115,11 +97,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </checkbox>
-</template>
-  
-
-  
-<template name="TPL_checkbox-group">
+</template><template name="TPL_checkbox-group">
   <checkbox-group 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -129,11 +107,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </checkbox-group>
-</template>
-  
-
-  
-<template name="TPL_contact-button">
+</template><template name="TPL_contact-button">
   <contact-button 
     alipay-card-no="{{node.props['alipay-card-no']}}" 
     class="{{node.props['class']}}" 
@@ -147,11 +121,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </contact-button>
-</template>
-  
-
-  
-<template name="TPL_cover-image">
+</template><template name="TPL_cover-image">
   <cover-image 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -161,11 +131,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </cover-image>
-</template>
-  
-
-  
-<template name="TPL_cover-view">
+</template><template name="TPL_cover-view">
   <cover-view 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -174,11 +140,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </cover-view>
-</template>
-  
-
-  
-<template name="TPL_form">
+</template><template name="TPL_form">
   <form 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -189,11 +151,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </form>
-</template>
-  
-
-  
-<template name="TPL_icon">
+</template><template name="TPL_icon">
   <icon 
     class="{{node.props['class']}}" 
     color="{{node.props['color']}}" 
@@ -204,11 +162,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </icon>
-</template>
-  
-
-  
-<template name="TPL_image">
+</template><template name="TPL_image">
   <image 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -226,11 +180,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </image>
-</template>
-  
-
-  
-<template name="TPL_input">
+</template><template name="TPL_input">
   <input 
     class="{{node.props['class']}}" 
     confirm-hold="{{node.props['confirm-hold']}}" 
@@ -260,11 +210,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </input>
-</template>
-  
-
-  
-<template name="TPL_label">
+</template><template name="TPL_label">
   <label 
     class="{{node.props['class']}}" 
     for="{{node.props['for']}}" 
@@ -273,22 +219,14 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </label>
-</template>
-  
-
-  
-<template name="TPL_lifestyle">
+</template><template name="TPL_lifestyle">
   <lifestyle 
     onFollow="{{node.props['onFollow']}}" 
     public-id="{{node.props['public-id']}}" 
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </lifestyle>
-</template>
-  
-
-  
-<template name="TPL_lottie">
+</template><template name="TPL_lottie">
   <lottie 
     assetsPath="{{node.props['assetsPath']}}" 
     autoReverse="{{node.props['autoReverse']}}" 
@@ -313,10 +251,6 @@
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </lottie>
 </template>
-
-  
-
-  
 <template name="TPL_map">
   <map 
     circles="{{node.props['circles']}}" 
@@ -344,11 +278,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </map>
-</template>
-  
-
-  
-<template name="TPL_movable-area">
+</template><template name="TPL_movable-area">
   <movable-area 
     class="{{node.props['class']}}" 
     height="{{node.props['height']}}" 
@@ -358,11 +288,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </movable-area>
-</template>
-  
-
-  
-<template name="TPL_movable-view">
+</template><template name="TPL_movable-view">
   <movable-view 
     class="{{node.props['class']}}" 
     damping="{{node.props['damping']}}" 
@@ -390,11 +316,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </movable-view>
-</template>
-  
-
-  
-<template name="TPL_navigator">
+</template><template name="TPL_navigator">
   <navigator 
     class="{{node.props['class']}}" 
     hover-class="{{node.props['hover-class']}}" 
@@ -407,11 +329,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </navigator>
-</template>
-  
-
-  
-<template name="TPL_picker">
+</template><template name="TPL_picker">
   <picker 
     class="{{node.props['class']}}" 
     disabled="{{node.props['disabled']}}" 
@@ -428,10 +346,6 @@
     </view>
   </picker>
 </template>
-
-  
-
-  
 <template name="TPL_picker-view">
   <picker-view 
     class="{{node.props['class']}}" 
@@ -453,12 +367,7 @@
       </picker-view-column>
     </block>
   </picker-view>
-</template>
-  
-
-  
-  
-<template name="TPL_progress">
+</template><template name="TPL_progress">
   <progress 
     active="{{node.props['active']}}" 
     active-color="{{node.props['active-color']}}" 
@@ -472,11 +381,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </progress>
-</template>
-  
-
-  
-<template name="TPL_radio">
+</template><template name="TPL_radio">
   <radio 
     checked="{{node.props['checked']}}" 
     class="{{node.props['class']}}" 
@@ -489,11 +394,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </radio>
-</template>
-  
-
-  
-<template name="TPL_radio-group">
+</template><template name="TPL_radio-group">
   <radio-group 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -503,11 +404,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </radio-group>
-</template>
-  
-
-  
-<template name="TPL_rich-text">
+</template><template name="TPL_rich-text">
   <rich-text 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -522,11 +419,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </rich-text>
-</template>
-  
-
-  
-<template name="TPL_scroll-view">
+</template><template name="TPL_scroll-view">
   <scroll-view 
     class="{{node.props['class']}}" 
     enable-back-to-top="{{node.props['enable-back-to-top']}}" 
@@ -552,11 +445,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </scroll-view>
-</template>
-  
-
-  
-<template name="TPL_slider">
+</template><template name="TPL_slider">
   <slider 
     active-color="{{node.props['active-color']}}" 
     background-color="{{node.props['background-color']}}" 
@@ -578,11 +467,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </slider>
-</template>
-  
-
-  
-<template name="TPL_swiper">
+</template><template name="TPL_swiper">
   <swiper 
     acceleration="{{node.props['acceleration']}}" 
     active-class="{{node.props['active-class']}}" 
@@ -619,11 +504,6 @@
     </block>
   </swiper>
 </template>
-
-  
-
-  
-  
 <template name="TPL_switch">
   <switch 
     checked="{{node.props['checked']}}" 
@@ -638,11 +518,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </switch>
-</template>
-  
-
-  
-<template name="TPL_text">
+</template><template name="TPL_text">
   <text 
     class="{{node.props['class']}}" 
     decode="{{node.props['decode']}}" 
@@ -655,11 +531,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </text>
-</template>
-  
-
-  
-<template name="TPL_textarea">
+</template><template name="TPL_textarea">
   <textarea 
     auto-height="{{ node.props['auto-height'] }}" 
     class="{{ node.props['class'] }}" 
@@ -684,10 +556,6 @@
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </textarea>
 </template>
-
-  
-
-  
 <template name="TPL_video">
   <video 
     autoplay="{{node.props['autoplay']}}" 
@@ -722,11 +590,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </video>
-</template>
-  
-
-  
-<template name="TPL_view">
+</template><template name="TPL_view">
   <view 
     _tid="{{node.props['_tid']}}" 
     animation="{{node.props['animation']}}" 
@@ -756,11 +620,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </view>
-</template>
-  
-
-  
-<template name="TPL_web-view">
+</template><template name="TPL_web-view">
   <web-view 
     id="{{node.props['id']}}" 
     onMessage="{{node.props['onMessage']}}" 
@@ -769,22 +629,15 @@
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </web-view>
 </template>
-  
-
-
 <template name="TPL_plain-text">
   <block>{{ node.text }}</block>
 </template>
-
 <template name="TPL_block">
   <block>
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </block>
 </template>
-
-
-  <template is="TPL_TRAVERSAL" data="{{ root: root }}" />
-
+<template is="TPL_TRAVERSAL" data="{{ root: root }}" />
 
 <!-- for default render -->
 <template name="TPL_DEFAULT">

--- a/packages/remax-cli/src/__tests__/integration/fixtures/turbo-pages-swiper/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/turbo-pages-swiper/expected/pages/index.axml
@@ -1,7 +1,4 @@
-
 <import src="/isolated.axml"/>
-
-
 
 <template name="TPL_5da6971-1">
   <view ><template is="TPL_DEFAULT" data="{{root: node.children[0]}}" />
@@ -9,9 +6,6 @@
 
 </template>
 
-
-
-  
 <template name="TPL_button">
   <button 
     app-parameter="{{node.props['app-parameter']}}" 
@@ -37,11 +31,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </button>
-</template>
-  
-
-  
-<template name="TPL_camera">
+</template><template name="TPL_camera">
   <camera 
     applyMicPermissionWhenInit="{{node.props['applyMicPermissionWhenInit']}}" 
     class="{{node.props['class']}}" 
@@ -61,10 +51,6 @@
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </camera>
 </template>
-
-  
-
-  
 <template name="TPL_canvas">
   <canvas 
     class="{{node.props['class']}}" 
@@ -83,11 +69,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </canvas>
-</template>
-  
-
-  
-<template name="TPL_checkbox">
+</template><template name="TPL_checkbox">
   <checkbox 
     checked="{{node.props['checked']}}" 
     class="{{node.props['class']}}" 
@@ -101,11 +83,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </checkbox>
-</template>
-  
-
-  
-<template name="TPL_checkbox-group">
+</template><template name="TPL_checkbox-group">
   <checkbox-group 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -115,11 +93,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </checkbox-group>
-</template>
-  
-
-  
-<template name="TPL_contact-button">
+</template><template name="TPL_contact-button">
   <contact-button 
     alipay-card-no="{{node.props['alipay-card-no']}}" 
     class="{{node.props['class']}}" 
@@ -133,11 +107,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </contact-button>
-</template>
-  
-
-  
-<template name="TPL_cover-image">
+</template><template name="TPL_cover-image">
   <cover-image 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -147,11 +117,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </cover-image>
-</template>
-  
-
-  
-<template name="TPL_cover-view">
+</template><template name="TPL_cover-view">
   <cover-view 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -160,11 +126,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </cover-view>
-</template>
-  
-
-  
-<template name="TPL_form">
+</template><template name="TPL_form">
   <form 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -175,11 +137,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </form>
-</template>
-  
-
-  
-<template name="TPL_icon">
+</template><template name="TPL_icon">
   <icon 
     class="{{node.props['class']}}" 
     color="{{node.props['color']}}" 
@@ -190,11 +148,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </icon>
-</template>
-  
-
-  
-<template name="TPL_image">
+</template><template name="TPL_image">
   <image 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -212,11 +166,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </image>
-</template>
-  
-
-  
-<template name="TPL_input">
+</template><template name="TPL_input">
   <input 
     class="{{node.props['class']}}" 
     confirm-hold="{{node.props['confirm-hold']}}" 
@@ -246,11 +196,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </input>
-</template>
-  
-
-  
-<template name="TPL_label">
+</template><template name="TPL_label">
   <label 
     class="{{node.props['class']}}" 
     for="{{node.props['for']}}" 
@@ -259,22 +205,14 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </label>
-</template>
-  
-
-  
-<template name="TPL_lifestyle">
+</template><template name="TPL_lifestyle">
   <lifestyle 
     onFollow="{{node.props['onFollow']}}" 
     public-id="{{node.props['public-id']}}" 
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </lifestyle>
-</template>
-  
-
-  
-<template name="TPL_lottie">
+</template><template name="TPL_lottie">
   <lottie 
     assetsPath="{{node.props['assetsPath']}}" 
     autoReverse="{{node.props['autoReverse']}}" 
@@ -299,10 +237,6 @@
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </lottie>
 </template>
-
-  
-
-  
 <template name="TPL_map">
   <map 
     circles="{{node.props['circles']}}" 
@@ -330,11 +264,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </map>
-</template>
-  
-
-  
-<template name="TPL_movable-area">
+</template><template name="TPL_movable-area">
   <movable-area 
     class="{{node.props['class']}}" 
     height="{{node.props['height']}}" 
@@ -344,11 +274,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </movable-area>
-</template>
-  
-
-  
-<template name="TPL_movable-view">
+</template><template name="TPL_movable-view">
   <movable-view 
     class="{{node.props['class']}}" 
     damping="{{node.props['damping']}}" 
@@ -376,11 +302,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </movable-view>
-</template>
-  
-
-  
-<template name="TPL_navigator">
+</template><template name="TPL_navigator">
   <navigator 
     class="{{node.props['class']}}" 
     hover-class="{{node.props['hover-class']}}" 
@@ -393,11 +315,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </navigator>
-</template>
-  
-
-  
-<template name="TPL_picker">
+</template><template name="TPL_picker">
   <picker 
     class="{{node.props['class']}}" 
     disabled="{{node.props['disabled']}}" 
@@ -414,10 +332,6 @@
     </view>
   </picker>
 </template>
-
-  
-
-  
 <template name="TPL_picker-view">
   <picker-view 
     class="{{node.props['class']}}" 
@@ -439,12 +353,7 @@
       </picker-view-column>
     </block>
   </picker-view>
-</template>
-  
-
-  
-  
-<template name="TPL_progress">
+</template><template name="TPL_progress">
   <progress 
     active="{{node.props['active']}}" 
     active-color="{{node.props['active-color']}}" 
@@ -458,11 +367,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </progress>
-</template>
-  
-
-  
-<template name="TPL_radio">
+</template><template name="TPL_radio">
   <radio 
     checked="{{node.props['checked']}}" 
     class="{{node.props['class']}}" 
@@ -475,11 +380,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </radio>
-</template>
-  
-
-  
-<template name="TPL_radio-group">
+</template><template name="TPL_radio-group">
   <radio-group 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -489,11 +390,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </radio-group>
-</template>
-  
-
-  
-<template name="TPL_rich-text">
+</template><template name="TPL_rich-text">
   <rich-text 
     class="{{node.props['class']}}" 
     id="{{node.props['id']}}" 
@@ -508,11 +405,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </rich-text>
-</template>
-  
-
-  
-<template name="TPL_scroll-view">
+</template><template name="TPL_scroll-view">
   <scroll-view 
     class="{{node.props['class']}}" 
     enable-back-to-top="{{node.props['enable-back-to-top']}}" 
@@ -538,11 +431,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </scroll-view>
-</template>
-  
-
-  
-<template name="TPL_slider">
+</template><template name="TPL_slider">
   <slider 
     active-color="{{node.props['active-color']}}" 
     background-color="{{node.props['background-color']}}" 
@@ -564,11 +453,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </slider>
-</template>
-  
-
-  
-<template name="TPL_swiper">
+</template><template name="TPL_swiper">
   <swiper 
     acceleration="{{node.props['acceleration']}}" 
     active-class="{{node.props['active-class']}}" 
@@ -605,11 +490,6 @@
     </block>
   </swiper>
 </template>
-
-  
-
-  
-  
 <template name="TPL_switch">
   <switch 
     checked="{{node.props['checked']}}" 
@@ -624,11 +504,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </switch>
-</template>
-  
-
-  
-<template name="TPL_text">
+</template><template name="TPL_text">
   <text 
     class="{{node.props['class']}}" 
     decode="{{node.props['decode']}}" 
@@ -641,11 +517,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </text>
-</template>
-  
-
-  
-<template name="TPL_textarea">
+</template><template name="TPL_textarea">
   <textarea 
     auto-height="{{ node.props['auto-height'] }}" 
     class="{{ node.props['class'] }}" 
@@ -670,10 +542,6 @@
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </textarea>
 </template>
-
-  
-
-  
 <template name="TPL_video">
   <video 
     autoplay="{{node.props['autoplay']}}" 
@@ -708,11 +576,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </video>
-</template>
-  
-
-  
-<template name="TPL_view">
+</template><template name="TPL_view">
   <view 
     _tid="{{node.props['_tid']}}" 
     animation="{{node.props['animation']}}" 
@@ -741,11 +605,7 @@
   >
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </view>
-</template>
-  
-
-  
-<template name="TPL_web-view">
+</template><template name="TPL_web-view">
   <web-view 
     id="{{node.props['id']}}" 
     onMessage="{{node.props['onMessage']}}" 
@@ -754,22 +614,15 @@
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </web-view>
 </template>
-  
-
-
 <template name="TPL_plain-text">
   <block>{{ node.text }}</block>
 </template>
-
 <template name="TPL_block">
   <block>
     <template is="TPL_TRAVERSAL" data="{{root: node}}" />
   </block>
 </template>
-
-
-  <template is="TPL_TRAVERSAL" data="{{ root: root }}" />
-
+<template is="TPL_TRAVERSAL" data="{{ root: root }}" />
 
 <!-- for default render -->
 <template name="TPL_DEFAULT">

--- a/packages/remax-cli/src/__tests__/integration/fixtures/with-dsl-component/expected/pages/index.axml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/with-dsl-component/expected/pages/index.axml
@@ -6,460 +6,167 @@
   </block>
 </template>
 
-
-  
-  <template name="REMAX_TPL_1_button">
-  <button 
-    
+<template name="REMAX_TPL_1_button">
+  <button
     app-parameter="{{item.props['app-parameter']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     form-type="{{item.props['form-type']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     loading="{{item.props['loading']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onGetAuthorize="{{item.props['onGetAuthorize']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     plain="{{item.props['plain']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
     scope="{{item.props['scope']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_camera">
-  <camera 
-    
+<template name="REMAX_TPL_1_camera">
+  <camera
     applyMicPermissionWhenInit="{{item.props['applyMicPermissionWhenInit']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     device-position="{{item.props['device-position']}}"
-    
-    
-    
     flash="{{item.props['flash']}}"
-    
-    
-    
     frame-format="{{item.props['frame-format']}}"
-    
-    
-    
     frame-size="{{item.props['frame-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max-duration="{{item.props['max-duration']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onScanCode="{{item.props['onScanCode']}}"
-    
-    
-    
     onStop="{{item.props['onStop']}}"
-    
-    
-    
     outputDimension="{{item.props['outputDimension']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </camera>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_canvas">
-  <canvas 
-    
+<template name="REMAX_TPL_1_canvas">
+  <canvas
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </canvas>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox">
-  <checkbox 
-    
+<template name="REMAX_TPL_1_checkbox">
+  <checkbox
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_checkbox-group">
-  <checkbox-group 
-    
+<template name="REMAX_TPL_1_checkbox-group">
+  <checkbox-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </checkbox-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_contact-button">
-  <contact-button 
-    
+<template name="REMAX_TPL_1_contact-button">
+  <contact-button
     alipay-card-no="{{item.props['alipay-card-no']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     icon="{{item.props['icon']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     scene="{{item.props['scene']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tnt-inst-id="{{item.props['tnt-inst-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </contact-button>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-image">
-  <cover-image 
-    
+<template name="REMAX_TPL_1_cover-image">
+  <cover-image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_cover-view">
-  <cover-view 
-    
+<template name="REMAX_TPL_1_cover-view">
+  <cover-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </cover-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_dsl-module-index-c6c02ac">
-  <dsl-module-index-c6c02ac 
-    
+<template name="REMAX_TPL_1_dsl-module-index-c6c02ac">
+  <dsl-module-index-c6c02ac
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
     ref="{{item.props['__ref']}}"
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.props['slot']}}">
-        <view slot="{{item.props['slot']}}" 
+        <view
+          slot="{{item.props['slot']}}"
         >
           <block a:for="{{item.children}}" key="{{item.id}}">
             <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
@@ -470,806 +177,272 @@
         <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
       </block>
     </block>
-    
   </dsl-module-index-c6c02ac>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_form">
-  <form 
-    
+<template name="REMAX_TPL_1_form">
+  <form
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onReset="{{item.props['onReset']}}"
-    
-    
-    
     onSubmit="{{item.props['onSubmit']}}"
-    
-    
-    
     report-submit="{{item.props['report-submit']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </form>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_icon">
-  <icon 
-    
+<template name="REMAX_TPL_1_icon">
+  <icon
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     size="{{item.props['size']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </icon>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_image">
-  <image 
-    
+<template name="REMAX_TPL_1_image">
+  <image
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lazy-load="{{item.props['lazy-load']}}"
-    
-    
-    
     mode="{{item.props['mode']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onLoad="{{item.props['onLoad']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </image>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_input">
-  <input 
-    
+<template name="REMAX_TPL_1_input">
+  <input
     class="{{item.props['class']}}"
-    
-    
-    
     confirm-hold="{{item.props['confirm-hold']}}"
-    
-    
-    
     confirm-type="{{item.props['confirm-type']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     cursor="{{item.props['cursor']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     password="{{item.props['password']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     randomNumber="{{item.props['randomNumber']}}"
-    
-    
-    
     selection-end="{{item.props['selection-end']}}"
-    
-    
-    
     selection-start="{{item.props['selection-start']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     type="{{item.props['type']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </input>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_label">
-  <label 
-    
+<template name="REMAX_TPL_1_label">
+  <label
     class="{{item.props['class']}}"
-    
-    
-    
     for="{{item.props['for']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </label>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lifestyle">
-  <lifestyle 
-    
+<template name="REMAX_TPL_1_lifestyle">
+  <lifestyle
     onFollow="{{item.props['onFollow']}}"
-    
-    
-    
     public-id="{{item.props['public-id']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lifestyle>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_lottie">
-  <lottie 
-    
+<template name="REMAX_TPL_1_lottie">
+  <lottie
     assetsPath="{{item.props['assetsPath']}}"
-    
-    
-    
     autoReverse="{{item.props['autoReverse']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     djangoId="{{item.props['djangoId']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     md5="{{item.props['md5']}}"
-    
-    
-    
     onAnimationCancel="{{item.props['onAnimationCancel']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationRepeat="{{item.props['onAnimationRepeat']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onDataFailed="{{item.props['onDataFailed']}}"
-    
-    
-    
     onDataLoadReady="{{item.props['onDataLoadReady']}}"
-    
-    
-    
     onDataReady="{{item.props['onDataReady']}}"
-    
-    
-    
     optimize="{{item.props['optimize']}}"
-    
-    
-    
     path="{{item.props['path']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     repeatCount="{{item.props['repeatCount']}}"
-    
-    
-    
     speed="{{item.props['speed']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </lottie>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_map">
-  <map 
-    
+<template name="REMAX_TPL_1_map">
+  <map
     circles="{{item.props['circles']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     ground-overlays="{{item.props['ground-overlays']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     include-padding="{{item.props['include-padding']}}"
-    
-    
-    
     include-points="{{item.props['include-points']}}"
-    
-    
-    
     latitude="{{item.props['latitude']}}"
-    
-    
-    
     longitude="{{item.props['longitude']}}"
-    
-    
-    
     markers="{{item.props['markers']}}"
-    
-    
-    
     onCalloutTap="{{item.props['onCalloutTap']}}"
-    
-    
-    
     onControlTap="{{item.props['onControlTap']}}"
-    
-    
-    
     onMarkerTap="{{item.props['onMarkerTap']}}"
-    
-    
-    
     onRegionChange="{{item.props['onRegionChange']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     polygon="{{item.props['polygon']}}"
-    
-    
-    
     polyline="{{item.props['polyline']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     setting="{{item.props['setting']}}"
-    
-    
-    
     show-location="{{item.props['show-location']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     tile-overlay="{{item.props['tile-overlay']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </map>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-area">
-  <movable-area 
-    
+<template name="REMAX_TPL_1_movable-area">
+  <movable-area
     class="{{item.props['class']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-area>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_movable-view">
-  <movable-view 
-    
+<template name="REMAX_TPL_1_movable-view">
+  <movable-view
     class="{{item.props['class']}}"
-    
-    
-    
     damping="{{item.props['damping']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     friction="{{item.props['friction']}}"
-    
-    
-    
     height="{{item.props['height']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChangeEnd="{{item.props['onChangeEnd']}}"
-    
-    
-    
     onScale="{{item.props['onScale']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     out-of-bounds="{{item.props['out-of-bounds']}}"
-    
-    
-    
     scale="{{item.props['scale']}}"
-    
-    
-    
     scale-max="{{item.props['scale-max']}}"
-    
-    
-    
     scale-min="{{item.props['scale-min']}}"
-    
-    
-    
     scale-value="{{item.props['scale-value']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     width="{{item.props['width']}}"
-    
-    
-    
     x="{{item.props['x']}}"
-    
-    
-    
     y="{{item.props['y']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </movable-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_navigator">
-  <navigator 
-    
+<template name="REMAX_TPL_1_navigator">
+  <navigator
     class="{{item.props['class']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     open-type="{{item.props['open-type']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     url="{{item.props['url']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </navigator>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker">
-  <picker 
-    
+<template name="REMAX_TPL_1_picker">
+  <picker
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     range="{{item.props['range']}}"
-    
-    
-    
     range-key="{{item.props['range-key']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <view>
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </view>
-    
   </picker>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_picker-view">
-  <picker-view 
-    
+<template name="REMAX_TPL_1_picker-view">
+  <picker-view
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-class="{{item.props['indicator-class']}}"
-    
-    
-    
     indicator-style="{{item.props['indicator-style']}}"
-    
-    
-    
     mask-class="{{item.props['mask-class']}}"
-    
-    
-    
     mask-style="{{item.props['mask-style']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <picker-view-column>
         <view a:for="{{item.children}}">
@@ -1277,951 +450,319 @@
         </view>
       </picker-view-column>
     </block>
-    
   </picker-view>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_progress">
-  <progress 
-    
+<template name="REMAX_TPL_1_progress">
+  <progress
     active="{{item.props['active']}}"
-    
-    
-    
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     percent="{{item.props['percent']}}"
-    
-    
-    
     show-info="{{item.props['show-info']}}"
-    
-    
-    
     stroke-width="{{item.props['stroke-width']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </progress>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio">
-  <radio 
-    
+<template name="REMAX_TPL_1_radio">
+  <radio
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_radio-group">
-  <radio-group 
-    
+<template name="REMAX_TPL_1_radio-group">
+  <radio-group
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </radio-group>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_rich-text">
-  <rich-text 
-    
+<template name="REMAX_TPL_1_rich-text">
+  <rich-text
     class="{{item.props['class']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     nodes="{{item.props['nodes']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </rich-text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_scroll-view">
-  <scroll-view 
-    
+<template name="REMAX_TPL_1_scroll-view">
+  <scroll-view
     class="{{item.props['class']}}"
-    
-    
-    
     enable-back-to-top="{{item.props['enable-back-to-top']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     lower-threshold="{{item.props['lower-threshold']}}"
-    
-    
-    
     onScroll="{{item.props['onScroll']}}"
-    
-    
-    
     onScrollToLower="{{item.props['onScrollToLower']}}"
-    
-    
-    
     onScrollToUpper="{{item.props['onScrollToUpper']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     scroll-animation-duration="{{item.props['scroll-animation-duration']}}"
-    
-    
-    
     scroll-into-view="{{item.props['scroll-into-view']}}"
-    
-    
-    
     scroll-left="{{item.props['scroll-left']}}"
-    
-    
-    
     scroll-top="{{item.props['scroll-top']}}"
-    
-    
-    
     scroll-with-animation="{{item.props['scroll-with-animation']}}"
-    
-    
-    
     scroll-x="{{item.props['scroll-x']}}"
-    
-    
-    
     scroll-y="{{item.props['scroll-y']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     trap-scroll="{{item.props['trap-scroll']}}"
-    
-    
-    
     upper-threshold="{{item.props['upper-threshold']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </scroll-view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_slider">
-  <slider 
-    
+<template name="REMAX_TPL_1_slider">
+  <slider
     active-color="{{item.props['active-color']}}"
-    
-    
-    
     background-color="{{item.props['background-color']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     handle-color="{{item.props['handle-color']}}"
-    
-    
-    
     handle-size="{{item.props['handle-size']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     max="{{item.props['max']}}"
-    
-    
-    
     min="{{item.props['min']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onChanging="{{item.props['onChanging']}}"
-    
-    
-    
     show-value="{{item.props['show-value']}}"
-    
-    
-    
     step="{{item.props['step']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     track-size="{{item.props['track-size']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </slider>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_swiper">
-  <swiper 
-    
+<template name="REMAX_TPL_1_swiper">
+  <swiper
     acceleration="{{item.props['acceleration']}}"
-    
-    
-    
     active-class="{{item.props['active-class']}}"
-    
-    
-    
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     changing-class="{{item.props['changing-class']}}"
-    
-    
-    
     circular="{{item.props['circular']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     current="{{item.props['current']}}"
-    
-    
-    
     disable-programmatic-animation="{{item.props['disable-programmatic-animation']}}"
-    
-    
-    
     disable-touch="{{item.props['disable-touch']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     indicator-active-color="{{item.props['indicator-active-color']}}"
-    
-    
-    
     indicator-color="{{item.props['indicator-color']}}"
-    
-    
-    
     indicator-dots="{{item.props['indicator-dots']}}"
-    
-    
-    
     interval="{{item.props['interval']}}"
-    
-    
-    
     next-margin="{{item.props['next-margin']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     onTransition="{{item.props['onTransition']}}"
-    
-    
-    
     previous-margin="{{item.props['previous-margin']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     vertical="{{item.props['vertical']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
-      <swiper-item 
-         class="{{item.props['class']}}" 
-         id="{{item.props['id']}}" 
-         key="{{item.props['key']}}" 
-         style="{{item.props['style']}}" 
+      <swiper-item
+        class="{{item.props['class']}}"
+        id="{{item.props['id']}}"
+        key="{{item.props['key']}}"
+        style="{{item.props['style']}}"
       >
         <block a:for="{{item.children}}" key="{{item.id}}">
           <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
         </block>
       </swiper-item>
     </block>
-    
   </swiper>
 </template>
 
-  
-  
-  
-  
-  <template name="REMAX_TPL_1_switch">
-  <switch 
-    
+<template name="REMAX_TPL_1_switch">
+  <switch
     checked="{{item.props['checked']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     color="{{item.props['color']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onChange="{{item.props['onChange']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </switch>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_text">
-  <text 
-    
+<template name="REMAX_TPL_1_text">
+  <text
     class="{{item.props['class']}}"
-    
-    
-    
     decode="{{item.props['decode']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     number-of-lines="{{item.props['number-of-lines']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     selectable="{{item.props['selectable']}}"
-    
-    
-    
     space="{{item.props['space']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
+
     <block a:for="{{item.children}}" key="{{item.id}}">
       <block a:if="{{item.type === 'plain-text'}}">{{item.text}}</block>
       <template a:else is="REMAX_TPL_1_CONTAINER" data="{{item: item.children[0]}}" />
     </block>
-    
   </text>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_textarea">
-  <textarea 
-    
+<template name="REMAX_TPL_1_textarea">
+  <textarea
     auto-height="{{item.props['auto-height']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controlled="{{item.props['controlled']}}"
-    
-    
-    
     disabled="{{item.props['disabled']}}"
-    
-    
-    
     enableNative="{{item.props['enableNative']}}"
-    
-    
-    
     focus="{{item.props['focus']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     maxlength="{{item.props['maxlength']}}"
-    
-    
-    
     name="{{item.props['name']}}"
-    
-    
-    
     onBlur="{{item.props['onBlur']}}"
-    
-    
-    
     onConfirm="{{item.props['onConfirm']}}"
-    
-    
-    
     onFocus="{{item.props['onFocus']}}"
-    
-    
-    
     onInput="{{item.props['onInput']}}"
-    
-    
-    
     placeholder="{{item.props['placeholder']}}"
-    
-    
-    
     placeholder-class="{{item.props['placeholder-class']}}"
-    
-    
-    
     placeholder-style="{{item.props['placeholder-style']}}"
-    
-    
-    
     show-count="{{item.props['show-count']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
     value="{{item.props['value']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </textarea>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_video">
-  <video 
-    
+<template name="REMAX_TPL_1_video">
+  <video
     autoplay="{{item.props['autoplay']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     controls="{{item.props['controls']}}"
-    
-    
-    
     direction="{{item.props['direction']}}"
-    
-    
-    
     duration="{{item.props['duration']}}"
-    
-    
-    
     enableProgressGesture="{{item.props['enableProgressGesture']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     initial-time="{{item.props['initial-time']}}"
-    
-    
-    
     loop="{{item.props['loop']}}"
-    
-    
-    
     mobilenetHintType="{{item.props['mobilenetHintType']}}"
-    
-    
-    
     muted="{{item.props['muted']}}"
-    
-    
-    
     objectFit="{{item.props['objectFit']}}"
-    
-    
-    
     onEnded="{{item.props['onEnded']}}"
-    
-    
-    
     onError="{{item.props['onError']}}"
-    
-    
-    
     onFullScreenChange="{{item.props['onFullScreenChange']}}"
-    
-    
-    
     onLoading="{{item.props['onLoading']}}"
-    
-    
-    
     onPause="{{item.props['onPause']}}"
-    
-    
-    
     onPlay="{{item.props['onPlay']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTimeUpdate="{{item.props['onTimeUpdate']}}"
-    
-    
-    
     onUserAction="{{item.props['onUserAction']}}"
-    
-    
-    
     poster="{{item.props['poster']}}"
-    
-    
-    
     posterSize="{{item.props['posterSize']}}"
-    
-    
-    
     show-center-play-btn="{{item.props['show-center-play-btn']}}"
-    
-    
-    
     show-fullscreen-btn="{{item.props['show-fullscreen-btn']}}"
-    
-    
-    
     show-mute-btn="{{item.props['show-mute-btn']}}"
-    
-    
-    
     show-play-btn="{{item.props['show-play-btn']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </video>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_view">
-  <view 
-    
+<template name="REMAX_TPL_1_view">
+  <view
     animation="{{item.props['animation']}}"
-    
-    
-    
     class="{{item.props['class']}}"
-    
-    
-    
     disable-scroll="{{item.props['disable-scroll']}}"
-    
-    
-    
     hidden="{{item.props['hidden']}}"
-    
-    
-    
     hover-class="{{item.props['hover-class']}}"
-    
-    
-    
     hover-start-time="{{item.props['hover-start-time']}}"
-    
-    
-    
     hover-stay-time="{{item.props['hover-stay-time']}}"
-    
-    
-    
     hover-stop-propagation="{{item.props['hover-stop-propagation']}}"
-    
-    
-    
     id="{{item.props['id']}}"
-    
-    
-    
     onAnimationEnd="{{item.props['onAnimationEnd']}}"
-    
-    
-    
     onAnimationIteration="{{item.props['onAnimationIteration']}}"
-    
-    
-    
     onAnimationStart="{{item.props['onAnimationStart']}}"
-    
-    
-    
     onAppear="{{item.props['onAppear']}}"
-    
-    
-    
     onDisappear="{{item.props['onDisappear']}}"
-    
-    
-    
     onFirstAppear="{{item.props['onFirstAppear']}}"
-    
-    
-    
     onLongTap="{{item.props['onLongTap']}}"
-    
-    
-    
     onTap="{{item.props['onTap']}}"
-    
-    
-    
     onTouchCancel="{{item.props['onTouchCancel']}}"
-    
-    
-    
     onTouchEnd="{{item.props['onTouchEnd']}}"
-    
-    
-    
     onTouchMove="{{item.props['onTouchMove']}}"
-    
-    
-    
     onTouchStart="{{item.props['onTouchStart']}}"
-    
-    
-    
     onTransitionEnd="{{item.props['onTransitionEnd']}}"
-    
-    
-    
     style="{{item.props['style']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </view>
 </template>
 
-  
-  
-  
-  <template name="REMAX_TPL_1_web-view">
-  <web-view 
-    
+<template name="REMAX_TPL_1_web-view">
+  <web-view
     id="{{item.props['id']}}"
-    
-    
-    
     onMessage="{{item.props['onMessage']}}"
-    
-    
-    
     src="{{item.props['src']}}"
-    
-    
-    
   >
-    
     <block a:for="{{item.children}}" key="{{item.id}}">
       <template is="REMAX_TPL_1_CONTAINER" data="{{item: item}}" />
     </block>
-    
   </web-view>
 </template>
-
-  
-  
 
 <template name="REMAX_TPL_1_plain-text">
   <block>{{item.text}}</block>

--- a/packages/remax-toutiao/templates/base.ejs
+++ b/packages/remax-toutiao/templates/base.ejs
@@ -4,19 +4,21 @@
   </block>
 </template>
 
-<% for (let component of sortBy(Array.from(components.values()), 'id')) { %>
-  <% if (skipComponents.includes(component.id)) {
+<% for (let component of sortBy(Array.from(components.values()), 'id')) { -%>
+  <%_ if (skipComponents.includes(component.id)) {
     continue;
-  } else { %>
-    <%- include('./component.ejs', {
-      type: component.type,
-      props: component.props,
-      id: component.id,
-      type: component.type,
-      slotView: slotView
-    }) %>
-  <% } %>
-<% } %>
+  } else { -%>
+<%- include('./component.ejs', {
+  type: component.type,
+  props: component.props,
+  id: component.id,
+  type: component.type,
+  slotView: slotView
+}) -%>
+
+  <%_ } -%>
+<% } -%>
+
 <template name="REMAX_TPL_plain-text" data="{{i: i}}">
   <block>{{i.text}}</block>
 </template>

--- a/packages/remax-toutiao/templates/component.ejs
+++ b/packages/remax-toutiao/templates/component.ejs
@@ -1,8 +1,10 @@
 <template name="REMAX_TPL_<%=id%>">
-  <<%=id%> <% for(let i=0;i < props.length; i++) { %>
-    <%=props[i]%>="{{i.props['<%=props[i]%>']}}" <%} %>
+  <<%=id%>
+  <%_ for(let i=0;i < props.length; i++) { -%>
+    <%=props[i]%>="{{i.props['<%=props[i]%>']}}"
+  <%_ } -%>
   >
-    <% if (id === 'swiper') { %>
+    <%_ if (id === 'swiper') { -%>
     <block tt:for="{{i.children}}" tt:key="*this">
       <swiper-item key="{{i.nodes[item].props.key}}">
         <block tt:for="{{i.nodes[item].children}}" tt:key="*this" tt:for-item="sItem">
@@ -10,7 +12,7 @@
         </block>
       </swiper-item>
     </block>
-    <% } else if (id === 'picker-view') { %>
+    <%_ } else if (id === 'picker-view') { -%>
     <block tt:for="{{i.children}}" tt:key="*this">
       <picker-view-column>
         <view tt:for="{{i.nodes[item].children}}" tt:for-item="sItem">
@@ -18,11 +20,14 @@
         </view>
       </picker-view-column>
     </block>
-    <% } else if (type === 'native') { %>
+    <%_ } else if (type === 'native') { -%>
     <block tt:for="{{i.children}}" tt:key="*this">
       <block tt:if="{{i.nodes[item].props['slot']}}">
-        <view slot="{{i.nodes[item].props['slot']}}" <% for(let i=0;i < slotView.props.length; i++) { %>
-          <%=slotView.props[i]%>="{{i.nodes[item].props['<%=slotView.props[i]%>']}}" <%}%>
+        <view
+          slot="{{i.nodes[item].props['slot']}}"
+        <%_ for(let i=0;i < slotView.props.length; i++) { -%>
+          <%=slotView.props[i]%>="{{i.nodes[item].props['<%=slotView.props[i]%>']}}"
+        <%_ } -%>
         >
           <block tt:for="{{i.nodes[item].children}}" tt:key="*this" tt:for-item="sItem">
             <template is="{{'REMAX_TPL_' + i.nodes[item].nodes[sItem].type}}" data="{{i: i.nodes[item].nodes[sItem]}}" />
@@ -33,10 +38,10 @@
         <template is="{{'REMAX_TPL_' + i.nodes[item].type}}" data="{{i: i.nodes[item]}}" />
       </block>
     </block>
-    <% } else { %>
+    <%_ } else { -%>
     <block tt:for="{{i.children}}" tt:key="{{id}}">
       <template is="{{'REMAX_TPL_' + i.nodes[item].type}}" data="{{i: i.nodes[item]}}" />
     </block>
-    <% } %>
+    <%_ } -%>
   </<%=id%>>
 </template>

--- a/packages/remax-wechat/templates/base.ejs
+++ b/packages/remax-wechat/templates/base.ejs
@@ -1,52 +1,55 @@
 <template name="REMAX_TPL">
-	<block wx:for="{{root.children}}" wx:key="*this">
-		<template is="REMAX_TPL_1_CONTAINER" data="{{i: root.nodes[item], a: ''}}" />
-	</block>
+  <block wx:for="{{root.children}}" wx:key="*this">
+    <template is="REMAX_TPL_1_CONTAINER" data="{{i: root.nodes[item], a: ''}}" />
+  </block>
 </template>
 
 <wxs module="_h">
-	var elements = {};
-	module.exports = {
-		v: function(value) {
-			return value !== undefined ? value : '';
-		},
-		tid: function (type, ancestor) {
-			var items = ancestor.split(',');
-			var depth = 1;
+  var elements = {};
+  module.exports = {
+    v: function(value) {
+      return value !== undefined ? value : '';
+    },
+    tid: function (type, ancestor) {
+      var items = ancestor.split(',');
+      var depth = 1;
 
-			for (var i = 0; i < items.length; i++) {
-				if (type === items[i]) {
-					depth = depth + 1;
-				}
-			}
+      for (var i = 0; i < items.length; i++) {
+        if (type === items[i]) {
+          depth = depth + 1;
+        }
+      }
 
-			var id = 'REMAX_TPL_' + depth + '_' + type;
-			return id;
-		}
-	};
+      var id = 'REMAX_TPL_' + depth + '_' + type;
+      return id;
+    }
+  };
 </wxs>
-<% for (let component of sortBy(Array.from(components.values()), 'id')) { %>
-  <% var len = depth[component.id] || 10; %>
-  <% for (var i = 1; i <= len; i++) { %>
-    <% if (skipComponents.includes(component.id)) {
+
+<% for (let component of sortBy(Array.from(components.values()), 'id')) { -%>
+  <%_ var len = depth[component.id] || 10; -%>
+  <%_ for (var i = 1; i <= len; i++) { -%>
+    <%_ if (skipComponents.includes(component.id)) {
       continue;
-    } else { %>
-      <%- include('./component.ejs', {
-        components: components,
-        type: component.type,
-        props: component.props,
-        id: component.id,
-        templateId: i,
-        slotView: slotView
-      }) %>
-    <% } %>
-  <% } %>
-<% } %>
+    } else { -%>
+<%- include('./component.ejs', {
+  components: components,
+  type: component.type,
+  props: component.props,
+  id: component.id,
+  templateId: i,
+  slotView: slotView
+}) -%>
+
+    <%_ } -%>
+  <%_ } -%>
+<% } -%>
 <template name="REMAX_TPL_1_plain-text" data="{{i: i}}">
-	<block>{{i.text}}</block>
+  <block>{{i.text}}</block>
 </template>
-<% for (var i = 1; i <= depth['view']; i++) { %>
+
+<% for (var i = 1; i <= depth['view']; i++) { -%>
 <template name="REMAX_TPL_<%=i%>_CONTAINER" data="{{i: i}}">
-	<template is="{{_h.tid(i.type, a)}}" data="{{i: i, a: a + ',' + i.type, tid: <%=i%>}}" />
+  <template is="{{_h.tid(i.type, a)}}" data="{{i: i, a: a + ',' + i.type, tid: <%=i%>}}" />
 </template>
-<% } %>
+<% } -%>

--- a/packages/remax-wechat/templates/children.ejs
+++ b/packages/remax-wechat/templates/children.ejs
@@ -1,4 +1,4 @@
-<%_ if (id === 'swiper') { _%>
+<% if (id === 'swiper') { -%>
 <block wx:for="{{i.children}}" wx:key="*this">
   <swiper-item class="{{i.nodes[item].props.class}}" item-id="{{i.nodes[item].props.itemId}}" key="{{i.nodes[item].props.key}}">
     <block wx:for="{{i.nodes[item].children}}" wx:key="*this" wx:for-item="sItem">
@@ -6,11 +6,13 @@
     </block>
   </swiper-item>
 </block>
-<%_ } else if (type === 'native') { _%>
+<% } else if (type === 'native') { -%>
 <block wx:for="{{i.children}}" wx:key="*this">
   <block wx:if="{{i.nodes[item].props['slot']}}">
-    <view slot="{{i.nodes[item].props['slot']}}" <% for(let i=0;i < slotView.props.length; i++) { %>
-      <%=slotView.props[i]%>="{{i.nodes[item].props['<%=slotView.props[i]%>']}}" <%}%>
+    <view slot="{{i.nodes[item].props['slot']}}"
+    <%_ for(let i=0;i < slotView.props.length; i++) { %>
+      <%=slotView.props[i]%>="{{i.nodes[item].props['<%=slotView.props[i]%>']}}"
+    <%_ } -%>
     >
       <block wx:for="{{i.nodes[item].children}}" wx:key="*this" wx:for-item="sItem">
         <template is="{{'REMAX_TPL_' + (tid + 1) + '_CONTAINER'}}" data="{{i: i.nodes[item].nodes[sItem], a: a, tid: tid + 1 }}" />
@@ -21,8 +23,8 @@
     <template is="{{'REMAX_TPL_' + (tid + 1) + '_CONTAINER'}}" data="{{i: i.nodes[item], a: a, tid: tid + 1 }}" />
   </block>
 </block>
-<%_ } else { _%>
+<% } else { -%>
 <block wx:for="{{i.children}}" wx:key="*this">
   <template is="{{'REMAX_TPL_' + (tid + 1) + '_CONTAINER'}}" data="{{i: i.nodes[item], a: a, tid: tid + 1 }}" />
 </block>
-<%_ } _%>
+<% } -%>

--- a/packages/remax-wechat/templates/component.ejs
+++ b/packages/remax-wechat/templates/component.ejs
@@ -1,5 +1,5 @@
 <template name="REMAX_TPL_<%=templateId%>_<%=id%>">
-  <%_ function propsKeyTpl(props, isCatch) {
+  <%_ function propsKeyTpl(props, isCatch, indent) {
     // 互斥事件
     if (isCatch) {
       props = props.filter(key => key !== 'bindtouchmove')
@@ -8,24 +8,31 @@
     }
 
     return props
-      .map(key => `${key}="{{_h.v(i.props['${key}'])}}"`)
+      .map(key => `${indent}${key}="{{_h.v(i.props['${key}'])}}"`)
       .join('\n')
-  } _%>
-  <%_ if (id === 'view') { _%>
-  <%# view 标签需要区分是否含 catchtouchmove 事件，区分渲染模板 %>
+  } -%>
+  <%_ if (id === 'view') { -%>
+<%# view 标签需要区分是否含 catchtouchmove 事件，区分渲染模板 -%>
   <block wx:if="{{i.props['catchtouchmove']}}">
-    <<%=id%> <%- propsKeyTpl(props, true) %>>
-      <%- include('./children.ejs', { props: props, id: id, type: type, slotView: slotView }) %>
+    <<%=id%>
+<%- propsKeyTpl(props, true, '      ') %>
+    >
+<%- include('./children.ejs', { props: props, id: id, type: type, slotView: slotView }) -%>
     </<%=id%>>
   </block>
+
   <block wx:else>
-    <<%=id%> <%- propsKeyTpl(props, false) %>>
-      <%- include('./children.ejs', { props: props, id: id, type: type, slotView: slotView }) %>
+    <<%=id%>
+<%- propsKeyTpl(props, false, '      ') %>
+    >
+<%- include('./children.ejs', { props: props, id: id, type: type, slotView: slotView }) -%>
     </<%=id%>>
   </block>
-  <%_ } else { _%>
-  <<%=id%> <%- propsKeyTpl(props, false) %>>
-    <%- include('./children.ejs', { props: props, id: id, type: type, slotView: slotView }) %>
+  <%_ } else { -%>
+  <<%=id%>
+<%- propsKeyTpl(props, false, '    ') %>
+  >
+<%- include('./children.ejs', { props: props, id: id, type: type, slotView: slotView }) -%>
   </<%=id%>>
-  <%_ } _%>
+  <%_ } -%>
 </template>


### PR DESCRIPTION
Make the output templates more human-readable and trackable (in dev mode).
Check the updated snapshots for more details.

---

[Ref](https://github.com/mde/ejs/blob/main/docs/syntax.md#whitespace-1)

> The use of scriptlets might cause some useless whitespace, as illustrated by the example below. You can trim it by
> 1. using the -%> ending tag, and
> 2. using the <%_ starting tag or starting the tag in the beginning of a line.