### PR TITLE
chore: touch deps & add continue-on-error to ci

### DIFF
--- a/.github/workflows/e2e-web-mpa.yml
+++ b/.github/workflows/e2e-web-mpa.yml
@@ -3,8 +3,12 @@ name: E2E web mpa
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   test:

--- a/.github/workflows/e2e-web-spa.yml
+++ b/.github/workflows/e2e-web-spa.yml
@@ -3,8 +3,12 @@ name: E2E web spa
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,12 @@ name: Lint
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   build:

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -6,6 +6,7 @@ jobs:
   to_gitee:
     if: github.repository == 'remaxjs/remax'
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v1
       - uses: pixta-dev/repository-mirroring-action@v1
@@ -16,6 +17,7 @@ jobs:
   to_gitee_gh:
     if: github.repository == 'remaxjs/remax'
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v1
       - uses: pixta-dev/repository-mirroring-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,12 @@ name: Build & Test
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   build:

--- a/docs/guide/one/web.md
+++ b/docs/guide/one/web.md
@@ -22,18 +22,25 @@ $ remax build -t web
 ```js
 // app.config.js
 module.exports.web = {
-  // 页面默认标题
-  title: '页面默认标题',
   // 配置的页面
   pages: ['pages/index/index'],
-  // 是否全局开启下拉刷新
-  pullToRefresh: false,
-  // 触底滚动的默认距离，单位 px
-  reachBottomOffset: 50,
+
+  window: {
+    // 页面默认标题
+    defaultTitle: '页面默认标题',
+
+    // 是否全局开启下拉刷新
+    pullRefresh: false,
+
+    // 触底滚动的默认距离，单位 px
+    reachBottomOffset: 50,
+  },
+
   router: {
     // history 类型，支持 hash 和 browser
     type: 'hash',
   },
+
   // tab bar 配置
   tabBar: {
     // 背景色
@@ -66,12 +73,14 @@ module.exports.web = {
 ```js
 // app.config.js
 module.exports.web = {
-  // 页面标题
-  title: '页面标题',
-  // 是否开启下拉刷新
-  pullToRefresh: false,
-  // 触底滚动的距离，单位 px
-  reachBottomOffset: 50,
+  window: {
+    // 页面标题
+    defaultTitle: '页面标题',
+    // 是否开启下拉刷新
+    pullRefresh: false,
+    // 触底滚动的距离，单位 px
+    reachBottomOffset: 50,
+  }
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "scripts": {
     "watch": "concurrently \"lerna run build:cjs --parallel -- -w\" \"tsc -b -w\"",
-    "prebuild": "npm run clean:packages",
     "build": "tsc -b && lerna run build:cjs",
     "test": "lerna run --ignore babel-preset-remax --ignore website --ignore e2e-* --stream test",
     "test:e2e-web": "lerna run --stream --scope e2e-app test:web",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "watch": "concurrently \"lerna run build:cjs --parallel -- -w\" \"tsc -b -w\"",
+    "prebuild": "npm run clean:packages",
     "build": "tsc -b && lerna run build:cjs",
     "test": "lerna run --ignore babel-preset-remax --ignore website --ignore e2e-* --stream test",
     "test:e2e-web": "lerna run --stream --scope e2e-app test:web",

--- a/packages/babel-preset-remax/package.json
+++ b/packages/babel-preset-remax/package.json
@@ -30,7 +30,7 @@
     "@babel/preset-env": "^7.7.4",
     "@babel/preset-react": "^7.7.4",
     "@babel/preset-typescript": "^7.7.4",
-    "@umijs/babel-plugin-auto-css-modules": "^3.1.1",
+    "@umijs/babel-plugin-auto-css-modules": "^3.3.1",
     "babel-plugin-auto-import": "^1.0.5",
     "babel-plugin-macros": "^2.8.0",
     "lodash": "^4.17.15"

--- a/packages/remax-macro/package.json
+++ b/packages/remax-macro/package.json
@@ -34,8 +34,7 @@
   },
   "dependencies": {
     "@remax/shared": "2.10.1",
-    "@remax/types": "2.10.1",
-    "@types/babel__traverse": "^7.0.8"
+    "@remax/types": "2.10.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/remax-one/package.json
+++ b/packages/remax-one/package.json
@@ -37,8 +37,7 @@
     "@remax/wechat": "2.10.1",
     "clsx": "^1.1.0",
     "memoize-one": "^5.1.1",
-    "react-autosize-textarea": "^7.0.0",
-    "rmc-feedback": "^2.0.0"
+    "react-autosize-textarea": "^7.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/remax-web/src/index.ts
+++ b/packages/remax-web/src/index.ts
@@ -7,3 +7,4 @@ export { default as usePageInstance } from './hooks/usePageInstance';
 export { default as bootstrap } from './bootstrap';
 export { default as bootstrapMpa } from './bootstrapMpa';
 export * from './api';
+export * from './types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3566,13 +3566,18 @@
   dependencies:
     "@umijs/utils" "3.3.0"
 
-"@umijs/babel-plugin-auto-css-modules@3.3.0", "@umijs/babel-plugin-auto-css-modules@^3.1.1":
+"@umijs/babel-plugin-auto-css-modules@3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@umijs/babel-plugin-auto-css-modules/-/babel-plugin-auto-css-modules-3.3.0.tgz#c43e68197d840a1504f96b212a8ff2c67cf7f8b7"
   integrity sha512-G9FwCL8cbis+fDFErgD/yiFH4umaUr+Jsl35ZL+HDClcpLRvKeKYEEzG/9OuYUeSzOqNN4WlIVlI6+CMykOIkw==
   dependencies:
     "@babel/traverse" "7.12.5"
     "@umijs/utils" "3.3.0"
+
+"@umijs/babel-plugin-auto-css-modules@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@umijs/babel-plugin-auto-css-modules/-/babel-plugin-auto-css-modules-3.3.1.tgz#62230c97fcf0befbf3034960e6a4ac657886fce1"
+  integrity sha512-xEoHmroDHcRKpCbB/fjeZvkS+/CZzbR085HFlWhc+U9gdcUFw0IzYnxVsMw+FicGS9tbwxmO6moe8EbImrtYIw==
 
 "@umijs/babel-plugin-import-to-await-require@3.3.0":
   version "3.3.0"
@@ -14830,14 +14835,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
-
-rmc-feedback@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/rmc-feedback/-/rmc-feedback-2.0.0.tgz#cbc6cb3ae63c7a635eef0e25e4fbaf5ac366eeaa"
-  integrity sha512-5PWOGOW7VXks/l3JzlOU9NIxRpuaSS8d9zA3UULUCuTKnpwBHNvv1jSJzxgbbCQeYzROWUpgKI4za3X4C/mKmQ==
-  dependencies:
-    babel-runtime "6.x"
-    classnames "^2.2.5"
 
 rmc-pull-to-refresh@^1.0.12:
   version "1.0.13"


### PR DESCRIPTION
packages
- upgraded `@umijs/babel-plugin-auto-css-modules` for smaller size (ref: https://github.com/umijs/umi/pull/5764)
- fixed `web.md` documentation to match the correct usage
- export types from web
- removed unused `rmc-feedback` dependency

ci
- skip test/lint/e2e actions on docs directory
- ~~`clean:packages` before building is unnecessary (especially in CI)~~
- added [`continue-on-error: true`](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error) to make mirror action optional