### PR TITLE
fix: 修复remax/wechat中textarea的type错误

### DIFF
--- a/packages/remax-wechat/src/hostComponents/Textarea/index.ts
+++ b/packages/remax-wechat/src/hostComponents/Textarea/index.ts
@@ -4,7 +4,7 @@ import { createHostComponent } from '@remax/runtime';
 
 export interface TextareaProps extends BaseProps {
   name?: string;
-  value: any;
+  value?: any;
   placeholder?: string;
   placeholderStyle?: React.CSSProperties;
   placeholderClassName?: string;


### PR DESCRIPTION
# remax/wechat中的textarea类型错误

value值改为非必填

[官方文档链接](https://developers.weixin.qq.com/miniprogram/dev/component/textarea.html)

![image](https://user-images.githubusercontent.com/37829041/113649248-aae5b480-96c0-11eb-81af-7f9ea7765f8d.png)


