### PR TITLE
fix(wechat): 引用三方plugin时误报错

### DIFF
--- a/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-mini-plugin/expected/pages/mini/index.json
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-mini-plugin/expected/pages/mini/index.json
@@ -1,6 +1,7 @@
 {
   "usingComponents": {
     "mini-greet": "/components/mini-greet/index",
-    "react-greet": "/components/react-greet/index"
+    "react-greet": "/components/react-greet/index",
+    "myPlugin": "plugin://myPlugin"
   }
 }

--- a/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-mini-plugin/expected/plugin.json
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-mini-plugin/expected/plugin.json
@@ -7,6 +7,12 @@
     "mini-page": "pages/mini/index",
     "react-page": "pages/react/index"
   },
+  "plugins": {
+    "myPlugin": {
+      "version": "1.0.0",
+      "provider": "wxidxxxxxxxxxxxxxxxx"
+    }
+  },
   "pages": [
     "pages/mini/index",
     "pages/react/index"

--- a/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-mini-plugin/src/pages/mini/index.json
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-mini-plugin/src/pages/mini/index.json
@@ -1,6 +1,7 @@
 {
   "usingComponents": {
     "mini-greet": "/components/mini-greet/index",
-    "react-greet": "/components/react-greet/index"
+    "react-greet": "/components/react-greet/index",
+    "myPlugin": "plugin://myPlugin"
   }
 }

--- a/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-mini-plugin/src/plugin.json
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/hybrid-mini-plugin/src/plugin.json
@@ -7,6 +7,12 @@
     "mini-page": "pages/mini/index",
     "react-page": "pages/react/index"
   },
+  "plugins": {
+    "myPlugin": {
+      "version": "1.0.0",
+      "provider": "wxidxxxxxxxxxxxxxxxx"
+    }
+  },
   "pages": ["pages/mini/index", "pages/react/index"],
   "main": "main"
 }

--- a/packages/remax-cli/src/build/entries/NativeEntry.ts
+++ b/packages/remax-cli/src/build/entries/NativeEntry.ts
@@ -41,6 +41,9 @@ export default class NativeEntry extends VirtualEntry {
     const { usingComponents = {} } = this.readRawManifest();
     return Object.keys(usingComponents).reduce((acc: Map<string, NativeEntry>, name: string) => {
       const request: string = usingComponents[name];
+      if (request && request.startsWith('plugin://')) {
+        return acc;
+      }
       const fileExist = ['.js', '.ts'].some(ext => {
         const filename = this.builder.projectPath.resolveAsset(request + ext, this.filename);
         if (filename && fs.existsSync(filename)) {


### PR DESCRIPTION
# 修复微信引用三方plugin时错误报错

错误复现： 当在微信原生文件中的index.json中引用三方plugin时，代码如下

```json
{
  "component": true,
  "usingComponents": {
    "cert": "plugin://wxqmPlugin/cert"
  }
}
```
会报下面的错误
![image](https://user-images.githubusercontent.com/37829041/114804219-89c54800-9dd3-11eb-9e53-80cebf61ecc3.png)

## 修复方式

增加usingComponents为plugin时的判断（不需要查找相关本地依赖）

[微信plugin文档地址](https://developers.weixin.qq.com/miniprogram/dev/framework/plugin/using.html#%E4%BD%BF%E7%94%A8%E6%8F%92%E4%BB%B6)