### PR TITLE
fix: #1563使用react-devtools无法显示小程序组件名称

### DIFF
--- a/packages/remax-runtime/src/createHostComponent.ts
+++ b/packages/remax-runtime/src/createHostComponent.ts
@@ -12,5 +12,6 @@ export default function createHostComponent<P = any>(name: string, component?: R
     element = RuntimeOptions.get('pluginDriver').onCreateHostComponentElement(element) as React.DOMElement<any, any>;
     return element;
   });
+  Component.displayName = name;
   return RuntimeOptions.get('pluginDriver').onCreateHostComponent(Component);
 }

--- a/packages/remax-runtime/src/createNativeComponent.ts
+++ b/packages/remax-runtime/src/createNativeComponent.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 export default function createNativeComponent(name: string) {
-  return React.forwardRef((props, ref) => {
+  const Component = React.forwardRef((props, ref) => {
     const newProps: any = { ...props };
     newProps.__ref =
       typeof ref === 'function'
@@ -13,4 +13,6 @@ export default function createNativeComponent(name: string) {
           };
     return React.createElement(name, newProps, props.children);
   });
+  Component.displayName = name;
+  return Component;
 }


### PR DESCRIPTION
#1563，添加之后react-devtools会显示host component和小程序原生组件
![displayName](https://user-images.githubusercontent.com/5847884/119466637-677dfd00-bd77-11eb-8137-8e5f81b55994.png)
