### PR TITLE
feat: #1618通过收集到的host component减少base模板体积

### DIFF
--- a/packages/remax-build-store/src/index.ts
+++ b/packages/remax-build-store/src/index.ts
@@ -78,17 +78,20 @@ const Store = {
     return component.id;
   },
 
-  getCollectedComponents() {
-    this.registeredHostComponents.forEach((component, key) => {
-      if (!this.collectedComponents.has(key)) {
-        this.collectedComponents.set(key, {
-          id: key,
-          props: unique(component.props).sort(),
-          additional: component.additional,
-        });
-      }
-    });
-    return this.collectedComponents;
+  getCollectedComponents(onlyCollectedComponents = false) {
+    const resComponents = new Map(this.collectedComponents);
+    if (!onlyCollectedComponents) {
+      this.registeredHostComponents.forEach((component, key) => {
+        if (!this.collectedComponents.has(key)) {
+          resComponents.set(key, {
+            id: key,
+            props: unique(component.props).sort(),
+            additional: component.additional,
+          });
+        }
+      });
+    }
+    return resComponents;
   },
 
   generateTemplateId(filename: string) {

--- a/packages/remax-cli/OptionsSchema.json
+++ b/packages/remax-cli/OptionsSchema.json
@@ -48,6 +48,9 @@
     },
     "UNSAFE_wechatTemplateDepth": {
       "type": ["number", "object"]
+    },
+    "UNSAFE_extractOnlyCollectedComponents": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false

--- a/packages/remax-cli/src/build/webpack/plugins/ComponentAsset/createTemplate.ts
+++ b/packages/remax-cli/src/build/webpack/plugins/ComponentAsset/createTemplate.ts
@@ -8,7 +8,7 @@ import { slash } from '@remax/shared';
 import { getUsingComponents } from '../getUsingComponents';
 
 export function createRenderOptions(componentPath: string, compilation: compilation.Compilation, options: Options) {
-  const components = new Map(Store.getCollectedComponents());
+  const components = new Map(Store.getCollectedComponents(options.UNSAFE_extractOnlyCollectedComponents));
 
   getUsingComponents(componentPath, compilation, options).forEach(component => {
     components.set(component.id, {

--- a/packages/remax-cli/src/build/webpack/plugins/PageAsset/createTemplate.ts
+++ b/packages/remax-cli/src/build/webpack/plugins/PageAsset/createTemplate.ts
@@ -17,7 +17,7 @@ export function createRenderOptions(
   options: Options,
   filter = true
 ) {
-  const components = new Map(Store.getCollectedComponents());
+  const components = new Map(Store.getCollectedComponents(options.UNSAFE_extractOnlyCollectedComponents));
 
   if (filter) {
     getUsingComponents(page, compilation, options).forEach(component => {
@@ -88,7 +88,7 @@ export async function createBaseTemplate(
     return null;
   }
 
-  const components = new Map(Store.getCollectedComponents());
+  const components = new Map(Store.getCollectedComponents(options.UNSAFE_extractOnlyCollectedComponents));
 
   pages.forEach(page => {
     if (page instanceof PageEntry) {

--- a/packages/remax-types/src/index.ts
+++ b/packages/remax-types/src/index.ts
@@ -29,6 +29,7 @@ export interface BuildOptions {
   rootDir: string;
   compressTemplate?: boolean;
   UNSAFE_wechatTemplateDepth: number | { [key: string]: number };
+  UNSAFE_extractOnlyCollectedComponents?: boolean;
   configWebpack?: (params: { config: WebpackConfig; webpack: any }) => void;
   plugins: Plugin[];
   port?: number;


### PR DESCRIPTION
#1618。在remax.config.js中添加一个`UNSAFE_extractOnlyCollectedComponents`参数。当不传或者传入false的时候与之前的逻辑相同，在生成的base模板中将搜索的host component填入；当为true的时候，通过getCollectedComponents不返回所有的host component，只返回collectedComponents，减小生成的base模板体积。