### PR TITLE
修复微信小程序 textarea组件 disableDefaultPadding 参数不生效的问题

### DIFF
--- a/packages/remax-wechat/src/hostComponents/Textarea/node.ts
+++ b/packages/remax-wechat/src/hostComponents/Textarea/node.ts
@@ -32,6 +32,7 @@ export const alias = {
   onKeyboardHeightChange: 'bindkeyboardheightchange',
   confirmType: 'confirm-type',
   confirmHold: 'confirm-hold',
+  disableDefaultPadding: 'disable-default-padding',
 };
 
 export const props = Object.values(alias);


### PR DESCRIPTION
修复微信小程序 textarea组件 disableDefaultPadding 参数不生效的问题