### PR TITLE
[skip ci] chore: remove outdated travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@
 </p>
 
 <p class="badges" align="center">
-	<a href="https://travis-ci.org/remaxjs/remax">
-		<img src="https://img.shields.io/travis/remaxjs/remax/master?style=flat-square" alt="Travis CI build status" />
-	</a>
 	<a href="https://github.com/remaxjs/remax/actions?workflow=Node+CI">
 		<img src="https://github.com/remaxjs/remax/workflows/Build%20&%20Test/badge.svg" alt="CI build status" />
 	</a>


### PR DESCRIPTION
Before:

![2021-08-31 21 34 27](https://user-images.githubusercontent.com/14012511/131511923-27cf71ae-7f13-436b-994c-2877c677ef79.png)

after:

![2021-08-31 21 36 32](https://user-images.githubusercontent.com/14012511/131512246-ec39debb-cde1-4cab-b4ac-213ff446224f.png)

cc @yesmeck 


