### PR TITLE
修复web端在App/Page生命周期中无法触发小程序生命周期问题

### DIFF
--- a/packages/remax-web/src/PullToRefresh.tsx
+++ b/packages/remax-web/src/PullToRefresh.tsx
@@ -6,6 +6,9 @@ const RemaxPullToRefresh: React.FC<any> = props => {
   return (
     <PullToRefresh
       {...props}
+      getScrollContainer={() => {
+        document.body;
+      }}
       indicator={{
         activate: <LoadingIcon />,
         deactivate: <LoadingIcon />,


### PR DESCRIPTION
修复web端下拉组件的时候没有初始化Container的高度，导致在子组件中未触底则多次出发问题 #1689 