### PR TITLE
fix: #1689

### DIFF
--- a/packages/remax-web/src/PullToRefresh.tsx
+++ b/packages/remax-web/src/PullToRefresh.tsx
@@ -7,7 +7,7 @@ const RemaxPullToRefresh: React.FC<any> = props => {
     <PullToRefresh
       {...props}
       getScrollContainer={() => {
-        document.body;
+        return document.body;
       }}
       indicator={{
         activate: <LoadingIcon />,


### PR DESCRIPTION
close #1689 

修复1689的web端下拉频繁问题，之前并没有修复，没有return 
```js
return document.body;
```
![image](https://user-images.githubusercontent.com/4210367/135125981-c1aeb6e7-a33b-4710-b318-11b287a0a35c.png)
