### PR TITLE
fix: 修复微信cover-view不透传slot属性导致地图气泡置顶的问题

### DIFF
--- a/packages/remax-wechat/src/hostComponents/CoverView/index.ts
+++ b/packages/remax-wechat/src/hostComponents/CoverView/index.ts
@@ -6,6 +6,7 @@ export interface CoverViewProps extends BaseProps {
   /**	设置顶部滚动偏移量，仅在设置了 overflow-y: scroll 成为滚动元素后生效	2.1.0  */
   scrollTop?: number | string;
   markerId?: string;
+  slot?: string;
 }
 
 /**

--- a/packages/remax-wechat/src/hostComponents/CoverView/node.ts
+++ b/packages/remax-wechat/src/hostComponents/CoverView/node.ts
@@ -4,6 +4,7 @@ export const alias = {
   style: 'style',
   animation: 'animation',
   scrollTop: 'scroll-top',
+  slot: 'slot',
   markerId: 'marker-id',
   onTap: 'bindtap',
   onClick: 'bindtap',


### PR DESCRIPTION
https://github.com/remaxjs/remax/issues/1514

https://developers.weixin.qq.com/miniprogram/dev/component/map.html