### PR TITLE
fix(wechat): cover-view

### DIFF
--- a/packages/remax-cli/src/__tests__/integration/fixtures/mini-component-basic/expected/wechat/base.wxml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/mini-component-basic/expected/wechat/base.wxml
@@ -90,6 +90,7 @@
     app-parameter="{{_h.v(i.props['app-parameter'])}}"
     bindaddfriend="{{_h.v(i.props['bindaddfriend'])}}"
     bindaddgroupapp="{{_h.v(i.props['bindaddgroupapp'])}}"
+    bindchooseavatar="{{_h.v(i.props['bindchooseavatar'])}}"
     bindcontact="{{_h.v(i.props['bindcontact'])}}"
     binderror="{{_h.v(i.props['binderror'])}}"
     bindgetphonenumber="{{_h.v(i.props['bindgetphonenumber'])}}"

--- a/packages/remax-cli/src/__tests__/integration/fixtures/wechat-include/expected/__remax_runtime_options__.js
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/wechat-include/expected/__remax_runtime_options__.js
@@ -75,6 +75,7 @@ module.exports = {
       "onLaunchApp": "bindlaunchapp",
       "onAddFriend": "bindaddfriend",
       "onAddGroupApp": "bindaddgroupapp",
+      "onChooseAvatar": "bindchooseavatar",
       "onTap": "bindtap",
       "onClick": "bindtap"
     }

--- a/packages/remax-cli/src/__tests__/integration/fixtures/wechat-include/expected/base.wxml
+++ b/packages/remax-cli/src/__tests__/integration/fixtures/wechat-include/expected/base.wxml
@@ -90,6 +90,7 @@
     app-parameter="{{_h.v(i.props['app-parameter'])}}"
     bindaddfriend="{{_h.v(i.props['bindaddfriend'])}}"
     bindaddgroupapp="{{_h.v(i.props['bindaddgroupapp'])}}"
+    bindchooseavatar="{{_h.v(i.props['bindchooseavatar'])}}"
     bindcontact="{{_h.v(i.props['bindcontact'])}}"
     binderror="{{_h.v(i.props['binderror'])}}"
     bindgetphonenumber="{{_h.v(i.props['bindgetphonenumber'])}}"

--- a/packages/remax-wechat/src/hostComponents/CoverView/index.ts
+++ b/packages/remax-wechat/src/hostComponents/CoverView/index.ts
@@ -6,6 +6,7 @@ export interface CoverViewProps extends BaseProps {
   /**	设置顶部滚动偏移量，仅在设置了 overflow-y: scroll 成为滚动元素后生效	2.1.0  */
   scrollTop?: number | string;
   markerId?: string;
+  slot?: string;
 }
 
 /**

--- a/packages/remax-wechat/src/hostComponents/CoverView/node.ts
+++ b/packages/remax-wechat/src/hostComponents/CoverView/node.ts
@@ -3,6 +3,7 @@ export const alias = {
   className: 'class',
   style: 'style',
   animation: 'animation',
+  slot: 'slot',
   scrollTop: 'scroll-top',
   markerId: 'marker-id',
   onTap: 'bindtap',


### PR DESCRIPTION
fix: 修复微信cover-view不透传slot属性导致地图气泡置顶的问题